### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ import { Annotorious } from '@recogito/annotorious';
 const anno = new Annotorious({ image: 'hallstatt' }); // image element or ID
 ```
 
-Otherwise download the [latest release](https://github.com/recogito/recogito-js/releases/latest)
+Otherwise download the [latest release](https://github.com/recogito/annotorious/releases/latest)
 and include it in your web page.
 
 ```html


### PR DESCRIPTION
Was checking this project out and noticed a small typo in the readme where it links to the latest release of recogito-js instead of this repo's latest release.

This fixes that typo. 