### PR TITLE
support w3c annotations using <path> instead of <polygon>

### DIFF
--- a/src/ImageAnnotator.scss
+++ b/src/ImageAnnotator.scss
@@ -25,7 +25,7 @@
 
 .a9s-annotation, .a9s-selection {
 
-  rect, polygon {
+  rect, path, polygon {
     fill:transparent;
     cursor:pointer;
     vector-effect:non-scaling-stroke;


### PR DESCRIPTION
Hello everyone,

I am currently playing around with the annotorious openseadragon plugin, and I noticed that chrome couldn't set the fill opacity for the loaded annotations. I then realized that my w3c annotations use `<path>` instead of `<polygon>` and so the base css for annotations in annotorious wasn't applied. 

This PR fixes the issue where w3c annotations using the SvgSelector with `<path>` elements instead of `<polygon>` are not drawn with transparent fill-color.

Cheers,
Andreas 😃 