### PR TITLE
Prevents right clicks from triggering all behaviors.

### DIFF
--- a/src/AnnotationLayer.js
+++ b/src/AnnotationLayer.js
@@ -87,7 +87,7 @@ export default class AnnotationLayer extends EventEmitter {
 
     elem.addEventListener('mouseleave', () => {
       if (!this.tools?.current.isDrawing) {
-        if (this.currentHover === elem) 
+        if (this.currentHover === elem)
           this.emit('mouseLeaveAnnotation', annotation, elem);
 
         this.currentHover = null;
@@ -114,6 +114,7 @@ export default class AnnotationLayer extends EventEmitter {
   }
 
   _onMouseDown = evt => {
+    if (evt.button !== 0) return;  // left click
     if (!(this.readOnly || this.selectedShape || this.tools.current.isDrawing)) {
       // No active selection & not drawing now? Start drawing.
       this.tools.current.start(evt);

--- a/src/tools/EditableShape.js
+++ b/src/tools/EditableShape.js
@@ -1,21 +1,14 @@
-import EventEmitter from 'tiny-emitter';
+import Tool from './Tool';
 import { SVG_NAMESPACE } from '../util/SVG';
 
 const IMPLEMENTATION_MISSING = "An implementation is missing";
 
-export default class EditableShape extends EventEmitter {
+export default class EditableShape extends Tool {
 
   constructor(annotation, g, config, env) {
-    super();
+    super(g, config, env);
 
     this.annotation = annotation;
-
-    this.g = g;
-
-    this.config = config;
-    this.env = env;
-
-    this.svg = g.closest('svg');
 
     // Implementations need to override the handles list
     this.handles = [];
@@ -41,7 +34,7 @@ export default class EditableShape extends EventEmitter {
 
         this.scaleHandles(scale);
       });
-      
+
       this.resizeObserver.observe(this.svg.parentNode);
     }
   }
@@ -76,12 +69,12 @@ export default class EditableShape extends EventEmitter {
   }
 
   setHandleXY = (handle, x, y) => {
-    const inner = handle.querySelector('.a9s-handle-inner');	
-    inner.setAttribute('cx', x);	
-    inner.setAttribute('cy', y);	
+    const inner = handle.querySelector('.a9s-handle-inner');
+    inner.setAttribute('cx', x);
+    inner.setAttribute('cy', y);
 
-    const outer = handle.querySelector('.a9s-handle-outer');	
-    outer.setAttribute('cx', x);	
+    const outer = handle.querySelector('.a9s-handle-outer');
+    outer.setAttribute('cx', x);
     outer.setAttribute('cy', y);
   }
 
@@ -105,23 +98,8 @@ export default class EditableShape extends EventEmitter {
     });
   }
 
-  getSVGPoint = evt => {
-    const bbox = this.svg.getBoundingClientRect();
-
-    const x = evt.clientX - bbox.x;
-    const y = evt.clientY- bbox.y;
-
-    const pt = this.svg.createSVGPoint();
-
-    const { left, top } = this.svg.getBoundingClientRect();
-    pt.x = x + left;
-    pt.y = y + top;
-
-    return pt.matrixTransform(this.g.getScreenCTM().inverse());
-  }
-
   // Implementations MUST override theis method
-  get element() {	
+  get element() {
     throw new Error(IMPLEMENTATION_MISSING);
   }
 
@@ -129,7 +107,7 @@ export default class EditableShape extends EventEmitter {
   destroy() {
     if (this.resizeObserver)
       this.resizeObserver.disconnect();
-    
+
     this.resizeObserver = null;
   }
 

--- a/src/tools/Tool.js
+++ b/src/tools/Tool.js
@@ -15,9 +15,9 @@ export default class Tool extends EventEmitter {
 
     // Annotationlayer SVG element
     this.svg = g.closest('svg');
-    
+
     // SVG group holding all the a9s contents.
-    // In AnnotoriousOSD, this is the element the 
+    // In AnnotoriousOSD, this is the element the
     // transoform gets applied to.
     this.g = g;
 
@@ -25,7 +25,7 @@ export default class Tool extends EventEmitter {
     this.env = env;
 
     // We'll keep a flag set to false until
-    // the user has started moving, so we can 
+    // the user has started moving, so we can
     // fire the startSelection event
     this.started = false;
   }
@@ -38,16 +38,16 @@ export default class Tool extends EventEmitter {
 
       const x = evt.clientX - bbox.x;
       const y = evt.clientY - bbox.y;
-  
+
       const { left, top } = this.svg.getBoundingClientRect();
       pt.x = x + left;
       pt.y = y + top;
-  
+
       return pt.matrixTransform(this.g.getScreenCTM().inverse());
-    } else {    
+    } else {
       pt.x = evt.offsetX;
       pt.y = evt.offsetY;
-      
+
       return pt.matrixTransform(this.g.getCTM().inverse());
     }
   }
@@ -62,16 +62,17 @@ export default class Tool extends EventEmitter {
           this.emit('startSelection', { x, y });
           this.started = true;
         }
-    
+
         mouseMove(x, y, evt);
       }
 
       // Mouse move goes on SVG element
-      this.svg.addEventListener('mousemove', this.mouseMove);   
+      this.svg.addEventListener('mousemove', this.mouseMove);
     }
 
     if (mouseUp) {
       this.mouseUp = evt => {
+        if (evt.button !== 0) return;  // left click
         const { x , y } = this.getSVGPoint(evt);
         mouseUp(x, y, evt);
       }
@@ -82,19 +83,19 @@ export default class Tool extends EventEmitter {
 
     if (dblClick) {
       this.dblClick = evt => {
-        const { x , y } = this.getSVGPoint(evt);        
+        const { x , y } = this.getSVGPoint(evt);
         dblClick(x, y, evt);
       }
 
       this.svg.addEventListener('dblclick', this.dblClick);
     }
-     
+
   }
 
   detachListeners = () => {
     if (this.mouseMove)
       this.svg.removeEventListener('mousemove', this.mouseMove);
-    
+
     if (this.mouseUp)
       document.removeEventListener('mouseup', this.mouseUp);
 
@@ -108,7 +109,7 @@ export default class Tool extends EventEmitter {
     this.startDrawing(x, y, evt);
   }
 
-  /** 
+  /**
    * Tool implementations MUST override these
    */
 
@@ -122,7 +123,7 @@ export default class Tool extends EventEmitter {
 
   createEditableShape = annotation => {
     throw new Error(IMPLEMENTATION_MISSING);
-  } 
+  }
 
 }
 
@@ -134,8 +135,8 @@ Tool.supports = annotation => {
   throw new Error(IMPLEMENTATION_MISSING);
 }
 
-// Just some convenience shortcuts to client-core, for quicker 
-// importing in plugins. (In a way, the intention is to make the 
+// Just some convenience shortcuts to client-core, for quicker
+// importing in plugins. (In a way, the intention is to make the
 // Tool class serve as a kind of mini-SDK).
 export { default as Selection } from '@recogito/recogito-client-core/src/Selection';
 export { default as WebAnnotation } from '@recogito/recogito-client-core/src/WebAnnotation';

--- a/src/tools/polygon/EditablePolygon.js
+++ b/src/tools/polygon/EditablePolygon.js
@@ -32,7 +32,7 @@ export default class EditablePolygon extends EditableShape {
     this.svg.addEventListener('mouseup', this.onMouseUp);
 
     // SVG markup for this class looks like this:
-    // 
+    //
     // <g>
     //   <path class="a9s-selection mask"... />
     //   <g> <-- return this node as .element
@@ -42,7 +42,7 @@ export default class EditablePolygon extends EditableShape {
     //     <g class="a9s-handle" ...> ... </g>
     //     <g class="a9s-handle" ...> ... </g>
     //     ...
-    //   </g> 
+    //   </g>
     // </g>
 
     // 'g' for the editable polygon compound shape
@@ -53,7 +53,7 @@ export default class EditablePolygon extends EditableShape {
       .addEventListener('mousedown', this.onGrab(this.shape));
 
     this.mask = new Mask(env.image, this.shape.querySelector('.a9s-inner'));
-    
+
     this.containerGroup.appendChild(this.mask.element);
 
     this.elementGroup = document.createElementNS(SVG_NAMESPACE, 'g');
@@ -82,7 +82,7 @@ export default class EditablePolygon extends EditableShape {
   setPoints = (points) => {
     // Not using .toFixed(1) because that will ALWAYS
     // return one decimal, e.g. "15.0" (when we want "15")
-    const round = num => 
+    const round = num =>
       Math.round(10 * num) / 10;
 
     const str = points.map(pt => `${round(pt.x)},${round(pt.y)}`).join(' ');
@@ -100,6 +100,7 @@ export default class EditablePolygon extends EditableShape {
   }
 
   onGrab = grabbedElem => evt => {
+    if (evt.button !== 0) return;  // left click
     this.grabbedElem = grabbedElem;
     this.grabbedAt = this.getSVGPoint(evt);
   }
@@ -126,7 +127,7 @@ export default class EditablePolygon extends EditableShape {
 
         this.setPoints(updatedPoints);
         updatedPoints.forEach((pt, idx) => this.setHandleXY(this.handles[idx], pt.x, pt.y));
-        
+
         this.emit('update', toSVGTarget(this.shape, this.env.image));
       } else {
         const handleIdx = this.handles.indexOf(this.grabbedElem);

--- a/src/tools/rectangle/EditableRect.js
+++ b/src/tools/rectangle/EditableRect.js
@@ -1,13 +1,13 @@
 import EditableShape from '../EditableShape';
 import { SVG_NAMESPACE } from '../../util/SVG';
 import { format, setFormatterElSize } from '../../util/Formatting';
-import { 
-  drawRect, 
+import {
+  drawRect,
   drawRectMask,
   parseRectFragment,
-  getRectSize, 
-  setRectSize, 
-  toRectFragment, 
+  getRectSize,
+  setRectSize,
+  toRectFragment,
   setRectMaskSize
 } from '../../selectors/RectFragment';
 
@@ -25,7 +25,7 @@ export default class EditableRect extends EditableShape {
     const { x, y, w, h } = parseRectFragment(annotation);
 
     // SVG markup for this class looks like this:
-    // 
+    //
     // <g>
     //   <path class="a9s-selection mask"... />
     //   <g> <-- return this node as .element
@@ -35,7 +35,7 @@ export default class EditableRect extends EditableShape {
     //     <g class="a9s-handle" ...> ... </g>
     //     <g class="a9s-handle" ...> ... </g>
     //     <g class="a9s-handle" ...> ... </g>
-    //   </g> 
+    //   </g>
     // </g>
 
     // 'g' for the editable rect compound shape
@@ -53,14 +53,14 @@ export default class EditableRect extends EditableShape {
     this.rectangle.querySelector('.a9s-inner')
       .addEventListener('mousedown', this.onGrab(this.rectangle));
 
-    this.elementGroup.appendChild(this.rectangle);    
+    this.elementGroup.appendChild(this.rectangle);
 
     this.handles = [
-      [ x, y ], 
-      [ x + w, y ], 
-      [ x + w, y + h ], 
+      [ x, y ],
+      [ x + w, y ],
+      [ x + w, y + h ],
       [ x, y + h ]
-    ].map(t => { 
+    ].map(t => {
       const [ x, y ] = t;
       const handle = this.drawHandle(x, y);
 
@@ -77,7 +77,7 @@ export default class EditableRect extends EditableShape {
     format(this.rectangle, annotation, config.formatter);
 
     // The grabbed element (handle or entire group), if any
-    this.grabbedElem = null; 
+    this.grabbedElem = null;
 
     // Mouse xy offset inside the shape, if mouse pressed
     this.mouseOffset = null;
@@ -124,13 +124,15 @@ export default class EditableRect extends EditableShape {
   }
 
   onGrab = grabbedElem => evt => {
-    this.grabbedElem = grabbedElem; 
+    if (evt.button !== 0) return;  // left click
+    this.grabbedElem = grabbedElem;
     const pos = this.getSVGPoint(evt);
     const { x, y } = getRectSize(this.rectangle);
-    this.mouseOffset = { x: pos.x - x, y: pos.y - y };  
+    this.mouseOffset = { x: pos.x - x, y: pos.y - y };
   }
 
   onMouseMove = evt => {
+    if (evt.button !== 0) return;  // left click
     const constrain = (coord, max) =>
       coord < 0 ? 0 : ( coord > max ? max : coord);
 
@@ -146,17 +148,17 @@ export default class EditableRect extends EditableShape {
         const x = constrain(pos.x - this.mouseOffset.x, naturalWidth - w);
         const y = constrain(pos.y - this.mouseOffset.y, naturalHeight - h);
 
-        this.setSize(x, y, w, h); 
-        this.emit('update', toRectFragment(x, y, w, h, this.env.image)); 
+        this.setSize(x, y, w, h);
+        this.emit('update', toRectFragment(x, y, w, h, this.env.image));
       } else {
         // Mouse position replaces one of the corner coords, depending
         // on which handle is the grabbed element
         const handleIdx = this.handles.indexOf(this.grabbedElem);
-        const oppositeHandle = handleIdx < 2 ? 
+        const oppositeHandle = handleIdx < 2 ?
           this.handles[handleIdx + 2] : this.handles[handleIdx - 2];
 
         const { x, y, w, h } = this.stretchCorners(handleIdx, oppositeHandle, pos);
-        this.emit('update', toRectFragment(x, y, w, h, this.env.image)); 
+        this.emit('update', toRectFragment(x, y, w, h, this.env.image));
       }
     }
   }
@@ -166,8 +168,8 @@ export default class EditableRect extends EditableShape {
     this.mouseOffset = null;
   }
 
-  get element() {	
-    return this.elementGroup;	
+  get element() {
+    return this.elementGroup;
   }
 
   destroy() {


### PR DESCRIPTION
I tried to prevent right clicks everywhere but there is at least one behavior I couldn't find: adding points to a polygon (guessing it's somewhere in EditablePolygon.js but can't find it).  

I extended `EditableShape` from Tool to use `getSVGPoint` and it felt right but maybe it may have side effects?