### PR TITLE
Snippet use outer rect instead of whole annotation element

### DIFF
--- a/src/util/ImageSnippet.js
+++ b/src/util/ImageSnippet.js
@@ -1,14 +1,13 @@
 import { hasClass } from './SVG';
 
 export const getSnippet = (image, element) => {
-  // Annotation shape could be the element itself or a 
-  // child (in case of editable shapes, the element would be 
-  // the group with shape + handles)
-  const shape = hasClass(element, 'a9s-annotation') ? 
+  const annotation_element = hasClass(element, 'a9s-annotation') ?
     element : element.querySelector('a9s-annotation');
 
-  const kx = image.naturalWidth / image.width; 
-  const ky = image.naturalHeight / image.height; 
+  const shape = annotation_element.querySelector('rect.a9s-outer');
+
+  const kx = image.naturalWidth / image.width;
+  const ky = image.naturalHeight / image.height;
 
   const imageBounds = image.getBoundingClientRect();
   const shapeBounds = shape.getBoundingClientRect();
@@ -24,8 +23,8 @@ export const getSnippet = (image, element) => {
   snippet.height = height * ky;
   ctx.drawImage(image, x * kx, y * ky, width * kx, height * ky, 0, 0, width * kx, height * ky);
 
-  return { 
-    snippet, 
+  return {
+    snippet,
     transform: xy => {
       const px = x * kx + xy[0];
       const py = y * ky + xy[1];


### PR DESCRIPTION
the methods `.getImageSnippetById` and `.getSelectedImageSnippet` did not return the same result when an annotation is in edit mode (because the element includes the handles).

This was very annoying for cases when we want to show the user a preview of what he is selecting.

for example, when editing this:
<img width="214" alt="image" src="https://user-images.githubusercontent.com/7504247/157281734-3e0ee700-ae1b-4d3b-83df-621e75f65cf5.png">

it returns this image:
![image](https://user-images.githubusercontent.com/7504247/157281639-7a0e0b81-c1a0-4a15-b417-f7de14995dda.png)

but once the user press OK it returns this:
![image](https://user-images.githubusercontent.com/7504247/157281928-8c9ba305-c6c9-4bbe-b836-d35b75f8e9c1.png)
