### PR TITLE
Add config option to enable resizing of rects via edges

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -60,6 +60,7 @@
           image: 'hallstatt',
           locale: 'auto',
           drawOnSingleClick: true,
+          enableEdgeControls: true,
           widgets: [
             { widget: 'COMMENT' },
             { widget: 'TAG', vocabulary: [ 'Animal', 'Building', 'Waterbody'] }


### PR DESCRIPTION
This PR adds a property to the config object, `enableEdgeControls`, that defaults to `false` but when enabled allows for adjusting an Annotorious EditableRect via its edges. This is in response to a recent discussion: https://github.com/recogito/annotorious/discussions/274