### PR TITLE
GitHub URLs in package.json point to current project

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/recogito/annotorious.git"
+    "url": "git+https://github.com/annotorious/annotorious.git"
   },
   "keywords": [
     "Annotation",
@@ -20,9 +20,9 @@
   "author": "Rainer Simon",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/recogito/annotorious/issues"
+    "url": "https://github.com/annotorious/annotorious/issues"
   },
-  "homepage": "https://recogito.github.io/annotorious",
+  "homepage": "https://annotorious.github.io/",
   "funding": {
     "type": "patreon",
     "url": "https://www.patreon.com/rainersimon"


### PR DESCRIPTION
Update a few URLs in the `package.json` that were pointing to the project's previous location.

At the time of #292, I didn't think to search for other GH references to recogito throughout the codebase - sorry about that! This time I did a search on GitHub, and there don't look to be any other references relating to GH links (only imports, [naming conventions](https://github.com/annotorious/annotorious/blob/main/webpack.polyfills.js#L4)).