### PR TITLE
Account for viewer offset in setPosition

### DIFF
--- a/packages/annotorious-react/src/openseadragon/setPosition.ts
+++ b/packages/annotorious-react/src/openseadragon/setPosition.ts
@@ -2,6 +2,8 @@ import { ImageAnnotation } from '@annotorious/annotorious';
 import OpenSeadragon from 'openseadragon';
 
 const getAnnotationDomRect = (viewer: OpenSeadragon.Viewer, annotation: ImageAnnotation) => {
+  const viewerBounds = viewer.element.getBoundingClientRect();
+  
   // Annotation bounds (image coordinates)
   const { minX, minY, maxX, maxY } = annotation.target.selector.geometry.bounds;
 
@@ -9,13 +11,14 @@ const getAnnotationDomRect = (viewer: OpenSeadragon.Viewer, annotation: ImageAnn
   const topLeft = viewer.viewport.imageToViewerElementCoordinates(new OpenSeadragon.Point(minX, minY));
   const bottomRight = viewer.viewport.imageToViewerElementCoordinates(new OpenSeadragon.Point(maxX, maxY));
 
-  return { 
-    x: topLeft.x, 
-    right: bottomRight.x,
-    y: topLeft.y, 
-    bottom: bottomRight.y,
-    width: bottomRight.x - topLeft.x, 
-    height: bottomRight.y - topLeft.y 
+  // Account for viewer element offset
+  return {
+    x: topLeft.x + viewerBounds.x,
+    right: bottomRight.x + viewerBounds.x,
+    y: topLeft.y + viewerBounds.y,
+    bottom: bottomRight.y + viewerBounds.y,
+    width: bottomRight.x - topLeft.x,
+    height: bottomRight.y - topLeft.y,
   };
 }
 


### PR DESCRIPTION
`OpenSeadragonPopup`'s setPosition function call would always be relative to window instead of the OSD container. Added an offset to position the popup based on the viewer's position.