### PR TITLE
Fixed possible `undefined` reference exception on `selector` in `parseW3CImageAnnotation`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.idea
 dist
 node_modules
 **/config.json

--- a/packages/annotorious/src/model/w3c/W3CImageFormatAdapter.ts
+++ b/packages/annotorious/src/model/w3c/W3CImageFormatAdapter.ts
@@ -55,7 +55,7 @@ export const parseW3CImageAnnotation = (
       }
     }
   } : {
-    error: Error(`Unknown selector type: ${selector.type}`)
+    error: Error(`Unknown selector type: ${w3cSelector.type}`)
   };
 
 }


### PR DESCRIPTION
## Issue
This PR resolves the https://github.com/annotorious/annotorious/issues/322 issue

## Changes Made
In this PR I replaced accessing the `undefined` `selector` object on error creation with the `w3cSelector`