### PR TITLE
Full styling support in Pixi/OSD

### DIFF
--- a/packages/annotorious-core/src/model/DrawingStyle.ts
+++ b/packages/annotorious-core/src/model/DrawingStyle.ts
@@ -16,4 +16,6 @@ export interface DrawingStyle {
 
   strokeOpacity?: number;
 
+  strokeWidth?: number;
+
 }

--- a/packages/annotorious-openseadragon/test/index.html
+++ b/packages/annotorious-openseadragon/test/index.html
@@ -79,7 +79,11 @@
           drawingEnabled: false,
           drawingMode: 'click',
           style: function(annotation) {
-            return { fill: '#ff0000', stroke: '#ffff00' };
+            return { 
+              fill: '#ff0000', 
+              stroke: '#ff0000',
+              strokeOpacity: 0.9
+            };
           }
         });
 

--- a/packages/annotorious-openseadragon/test/index.html
+++ b/packages/annotorious-openseadragon/test/index.html
@@ -82,9 +82,8 @@
             return { 
               fill: '#ff0000', 
               fillOpacity: 0.1,
-              stroke: '#005500',
-              strokeOpacity: 11,
-              strokeWidth: 2
+              strokeOpacity: 0.9,
+              strokeWidth: 1
             };
           }
         });

--- a/packages/annotorious-openseadragon/test/index.html
+++ b/packages/annotorious-openseadragon/test/index.html
@@ -81,8 +81,10 @@
           style: function(annotation) {
             return { 
               fill: '#ff0000', 
-              stroke: '#ff0000',
-              strokeOpacity: 0.9
+              fillOpacity: 0.1,
+              stroke: '#005500',
+              strokeOpacity: 11,
+              strokeWidth: 2
             };
           }
         });


### PR DESCRIPTION
## In this PR

This PR adds full styling support to Annotorious OpenSeadragon:
- fill
- fillOpacity
- stroke
- strokeOpacity
- strokeWidth 🎉

Stroke width is counter-scaled based on zoom level. If there are only annotations with stroke with 0 or 1, no counter-scaling is done. In case stroke width is 1, [native lines](https://github.com/pixijs/pixijs/issues/5352) are used for performance.