### PR TITLE
Added parsing/serialization for the `update` props

### DIFF
--- a/packages/annotorious/src/model/w3c/W3CImageFormatAdapter.ts
+++ b/packages/annotorious/src/model/w3c/W3CImageFormatAdapter.ts
@@ -33,8 +33,6 @@ export const parseW3CImageAnnotation = (
   const { 
     creator,
     created,
-    updatedBy,
-    updated,
     body, 
     ...rest 
   } = annotation;
@@ -59,8 +57,6 @@ export const parseW3CImageAnnotation = (
       target: {
         created: created ? new Date(created) : undefined,
         creator: parseW3CUser(creator),
-        updated: updated ? new Date(updated) : undefined,
-        updatedBy: parseW3CUser(updatedBy),
         ...rest.target,
         annotation: annotationId,
         selector
@@ -80,8 +76,8 @@ export const serializeW3CImageAnnotation = (
     selector, 
     creator, 
     created, 
-    updated, 
-    updatedBy, 
+    updated: _updated,
+    updatedBy: _updatedBy,
     ...rest 
   } = annotation.target;
 
@@ -98,8 +94,6 @@ export const serializeW3CImageAnnotation = (
     body: serializeW3CBodies(annotation.bodies),
     created: created?.toISOString(),
     creator,
-    updated: updated?.toISOString(),
-    updatedBy,
     target: {
       ...rest,
       source,

--- a/packages/annotorious/src/model/w3c/W3CImageFormatAdapter.ts
+++ b/packages/annotorious/src/model/w3c/W3CImageFormatAdapter.ts
@@ -59,6 +59,8 @@ export const parseW3CImageAnnotation = (
       target: {
         created: created ? new Date(created) : undefined,
         creator: parseW3CUser(creator),
+        updated: updated ? new Date(updated) : undefined,
+        updatedBy: parseW3CUser(updatedBy),
         ...rest.target,
         annotation: annotationId,
         selector
@@ -94,8 +96,10 @@ export const serializeW3CImageAnnotation = (
     id: annotation.id,
     type: 'Annotation',
     body: serializeW3CBodies(annotation.bodies),
-    creator,
     created: created?.toISOString(),
+    creator,
+    updated: updated?.toISOString(),
+    updatedBy,
     target: {
       ...rest,
       source,


### PR DESCRIPTION
## Issue
This PR is related to the https://github.com/annotorious/annotorious/issues/325. As of now the `updated` & `updatedBy` properties are being destructed, but from annotation, but not processed. So then we'll be losing those props.

Was leaving those properties of the Core model a deliberate move? I thought that they belong there, as they are included in the `AnnotationTarget` 🤔 