### PR TITLE
Fixed high vulnerability dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4662,9 +4662,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.10.tgz",
-      "integrity": "sha512-2P8J7WWgmc355HUMlFrwofacvr98DAjoE52BfdbwQtyLH06XKwaL/FMnmKM2crF0iX4MpmMKoDlNCB1ok7zHCw==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+      "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",


### PR DESCRIPTION
After running the `npm i` in the root of the project I was greeted with the `1 high severity vulnerability` message: 
![image](https://github.com/annotorious/annotorious/assets/68850090/8fbe280e-653f-4e6b-8123-64b98db359b3)

Fortunately, `npm audit fix` knew what to do and just bumped `vite` version