### PR TITLE
#49 Added `id` prop to the `W3CAnnotationTarget`

### DIFF
--- a/packages/annotorious-core/src/model/W3CAnnotation.ts
+++ b/packages/annotorious-core/src/model/W3CAnnotation.ts
@@ -52,6 +52,8 @@ export interface W3CAnnotationBody {
 
 export interface W3CAnnotationTarget {
 
+  id?: string;
+
   source: string;
 
   selector?: AbstractW3CSelector;


### PR DESCRIPTION
## Issue
This PR addresses the https://github.com/recogito/text-annotator-js/issues/49 issue. The w3c targets could contain the `id`s, but they were not specified in the in the Typescript definition