### PR TITLE
@r6o #47 Made `useAnnotationStore` generic loose with default `Store<Annotation>`

### DIFF
--- a/packages/annotorious-react/src/Annotorious.tsx
+++ b/packages/annotorious-react/src/Annotorious.tsx
@@ -113,7 +113,7 @@ export const useAnnotator = <T extends Annotator<any, unknown>>() => {
   return anno as T;
 }
 
-export const useAnnotationStore = <T extends Store<Annotation>>() => {
+export const useAnnotationStore = <T extends unknown = Store<Annotation>>() => {
   const { anno } = useContext(AnnotoriousContext);
   return anno?.state.store as T | undefined;
 }


### PR DESCRIPTION
## Issue
This PR resolves the 1st part of the https://github.com/recogito/text-annotator-js/issues/47 issue:

> 1. When you try using `useAnnotationStore` hook with the `text-annotator-js` type `TextAnnotationStore` - you'll have a TS error!
> ![image](https://github.com/recogito/text-annotator-js/assets/68850090/7162c4c1-268d-4909-8783-013170d31b53)
> That would be expected because the `TextAnnotationStore` doesn't fully extend the `Store` type:
> https://github.com/recogito/text-annotator-js/blob/bd9e75cd682b809c54c46a3b78bf8bcaeff4a3b2/packages/text-annotator/src/state/TextAnnotationStore.ts#L4-L12
> Unfortunately, it blocks users from accessing the Core's store with typing relevant to the `TextAnnotation` 🤷🏻‍♂️ 