### PR TITLE
@r6o #47 Made `useAnnotator` generic loose w/ default `Annotator<any, unknown>`

### DIFF
--- a/packages/annotorious-react/src/Annotorious.tsx
+++ b/packages/annotorious-react/src/Annotorious.tsx
@@ -123,13 +123,13 @@ const _useAnnotations = <T extends Annotation>() => {
   return annotations as T[];
 }
 
-const _useAnnotationsDebouced = <T extends Annotation>(debounce: number) => {
+const _useAnnotationsDebounced = <T extends Annotation>(debounce: number) => {
   const { annotations } = useContext(AnnotoriousContext);
   return useDebounce(annotations, debounce) as T[];
 }
 
 export const useAnnotations = <T extends Annotation>(debounce?: number) =>
-  debounce ? _useAnnotationsDebouced<T>(debounce) : _useAnnotations<T>();
+  debounce ? _useAnnotationsDebounced<T>(debounce) : _useAnnotations<T>();
 
 export const useSelection = <T extends Annotation>() => {
   const { selection } = useContext(AnnotoriousContext);

--- a/packages/annotorious-react/src/Annotorious.tsx
+++ b/packages/annotorious-react/src/Annotorious.tsx
@@ -108,7 +108,7 @@ export const Annotorious = forwardRef<Annotator, { children: ReactNode }>((props
 
 });
 
-export const useAnnotator = <T extends Annotator<any, unknown>>() => {
+export const useAnnotator = <T extends unknown = Annotator<any, unknown>>() => {
   const { anno } = useContext(AnnotoriousContext);
   return anno as T;
 }


### PR DESCRIPTION
## Issue
This PR is a follow-up of the #374. I faced the issue with using a `TextAnnotator<W3CTextAnnotation>` with the `useAnnotator`: 
![image](https://github.com/annotorious/annotorious/assets/68850090/5871129e-11f1-42ed-ad9e-5fc13a21d4a0)

That's because: 
> the `TextAnnotationStore` doesn't fully extend the `Store` type:
> https://github.com/recogito/text-annotator-js/blob/bd9e75cd682b809c54c46a3b78bf8bcaeff4a3b2/packages/text-annotator/src/state/TextAnnotationStore.ts#L4-L12
> Unfortunately, it blocks users from accessing the Core's store with typing relevant to the `TextAnnotation` 🤷🏻‍♂️ 