### PR TITLE
Added `replace` argument for the `setAnnotations`

### DIFF
--- a/packages/annotorious-core/src/model/Annotator.ts
+++ b/packages/annotorious-core/src/model/Annotator.ts
@@ -34,7 +34,7 @@ export interface Annotator<I extends Annotation = Annotation, E extends unknown 
 
   getUser(): User;
 
-  loadAnnotations(url: string): Promise<E[]>;
+  loadAnnotations(url: string, replace?: boolean): Promise<E[]>;
 
   redo(): void;
 
@@ -120,11 +120,11 @@ export const createBaseAnnotator = <I extends Annotation, E extends unknown>(
       : selected as unknown as E[];
   }
 
-  const loadAnnotations = (url: string) =>
+  const loadAnnotations = (url: string, replace = true) =>
     fetch(url)
       .then((response) => response.json())
       .then((annotations) => {
-        setAnnotations(annotations);
+        setAnnotations(annotations, replace);
         return annotations;
       });
 

--- a/packages/annotorious-core/src/model/Annotator.ts
+++ b/packages/annotorious-core/src/model/Annotator.ts
@@ -40,7 +40,7 @@ export interface Annotator<I extends Annotation = Annotation, E extends unknown 
 
   removeAnnotation(arg: E | string): E | undefined;
 
-  setAnnotations(annotations: E[]): void;
+  setAnnotations(annotations: E[], replace?: boolean): void;
 
   setFilter(filter: Filter | undefined): void;
 
@@ -145,16 +145,16 @@ export const createBaseAnnotator = <I extends Annotation, E extends unknown>(
     }
   }
 
-  const setAnnotations = (annotations: E[]) => {
+  const setAnnotations = (annotations: E[], replace = true) => {
     if (adapter) {
       const { parsed, failed } = parseAll(adapter)(annotations);
 
       if (failed.length > 0)
         console.warn(`Discarded ${failed.length} invalid annotations`, failed);
 
-      store.bulkAddAnnotation(parsed, true, Origin.REMOTE);
+      store.bulkAddAnnotation(parsed, replace, Origin.REMOTE);
     } else {
-      store.bulkAddAnnotation(annotations as unknown as I[], true, Origin.REMOTE);
+      store.bulkAddAnnotation(annotations as unknown as I[], replace, Origin.REMOTE);
     }
   }
 


### PR DESCRIPTION
## Issue
`Annotator` type is a public API of the library:
https://github.com/annotorious/annotorious/blob/adc3f3b793de47731119efc1a35b8c03af2beb8c/packages/annotorious-core/src/model/Annotator.ts#L15-L65
The **_`setAnnotations`_** is a method to add annotations in a bulk way to the store using the provided `adapter`:
https://github.com/annotorious/annotorious/blob/adc3f3b793de47731119efc1a35b8c03af2beb8c/packages/annotorious-core/src/model/Annotator.ts#L148-L159
###### That function is a primary way to add multiple annotations at once w/o using the `loadAnnotations` method, which can be unsuitable in many scenarios (specific auth rules, offline-first env, specific app storage, etc.)

Unfortunately, on the subsequent runs of that function - it'll always replace all the existing annotations in the store 😱. This is not desired when the loading happens page by page and we don't want to load insert the same page time after time. 

## Changes Made
I added the `replace` argument that can be controlled from the outside of the library