### PR TITLE
Added missing `@annotorious/openseadragon` to peer deps of `@annotorious/react`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5188,6 +5188,7 @@
       },
       "peerDependencies": {
         "@annotorious/annotorious": "*",
+        "@annotorious/openseadragon": "*",
         "openseadragon": "^3.0.0 || ^4.0.0",
         "react": "16.8.0 || >=17.x || >=18.x",
         "react-dom": "16.8.0 || >=17.x || >=18.x"

--- a/packages/annotorious-react/package.json
+++ b/packages/annotorious-react/package.json
@@ -34,6 +34,7 @@
   },
   "peerDependencies": {
     "@annotorious/annotorious": "*",
+    "@annotorious/openseadragon": "*",
     "openseadragon": "^3.0.0 || ^4.0.0",
     "react": "16.8.0 || >=17.x || >=18.x",
     "react-dom": "16.8.0 || >=17.x || >=18.x"


### PR DESCRIPTION
## Issue
The issue is similar to #384, so I would recommend checking it first.
The `@annotorious/openseadragon` is not being installed when you download the sources of the `@annotorious/react` and run `npm install`. And that leads to a failed `build` script 🤷🏻‍♂️ 