### PR TITLE
Made packages use standalone dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5214,6 +5214,9 @@
       "name": "@annotorious/react-manifold",
       "version": "3.0.0-rc.19",
       "license": "BSD-3-Clause",
+      "dependencies": {
+        "@annotorious/react": "*"
+      },
       "devDependencies": {
         "@types/react": "^18.2.48",
         "@types/react-dom": "^18.2.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5179,6 +5179,8 @@
       "version": "3.0.0-rc.19",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@annotorious/annotorious": "*",
+        "@annotorious/core": "*",
         "@annotorious/openseadragon": "*",
         "@neodrag/react": "^2.0.3"
       },
@@ -5193,6 +5195,7 @@
       },
       "peerDependencies": {
         "@annotorious/annotorious": "*",
+        "@annotorious/core": "*",
         "@annotorious/openseadragon": "*",
         "openseadragon": "^3.0.0 || ^4.0.0",
         "react": "16.8.0 || >=17.x || >=18.x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5237,6 +5237,11 @@
       "name": "@annotorious/svelte",
       "version": "3.0.0-rc.19",
       "license": "BSD-3-Clause",
+      "dependencies": {
+        "@annotorious/annotorious": "*",
+        "@annotorious/core": "*",
+        "@annotorious/openseadragon": "*"
+      },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^3.0.1",
         "@tsconfig/svelte": "^5.0.2",
@@ -5251,6 +5256,7 @@
       },
       "peerDependencies": {
         "@annotorious/annotorious": "*",
+        "@annotorious/core": "*",
         "@annotorious/openseadragon": "*",
         "openseadragon": "^3.0.0 || ^4.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3470,9 +3470,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.4.tgz",
-      "integrity": "sha512-vAjmBf13gsmhXSgBrtIclinISzFFy22WwCYoyilZlsrRXNIHSwgFQ1bEdjRwMT3aoadeIF6HMuDRlOxzfXV8ig==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.6.tgz",
+      "integrity": "sha512-rRq0eMHoGZxlvaFOUdK1Ev83Bd1IgzzR+WJ3IbDJ7QOSdAxYjlurSPqFs9s4lJg29RT6nPwizFtJhQS6V5xgiA==",
       "funding": [
         {
           "type": "github",
@@ -5129,7 +5129,7 @@
       "dependencies": {
         "dequal": "^2.0.3",
         "nanoevents": "^9.0.0",
-        "nanoid": "^5.0.4",
+        "nanoid": "^5.0.6",
         "uuid": "^9.0.1"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5120,6 +5120,9 @@
         "vite": "^5.0.12",
         "vite-plugin-dts": "^3.7.2",
         "vitest": "^1.2.1"
+      },
+      "peerDependencies": {
+        "@annotorious/core": "*"
       }
     },
     "packages/annotorious-core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5154,6 +5154,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@annotorious/annotorious": "*",
+        "@annotorious/core": "*",
         "@neodrag/svelte": "^2.0.3",
         "pixi.js": "^6.5.10",
         "uuid": "^9.0.1"
@@ -5171,6 +5172,8 @@
         "vite-plugin-dts": "^3.7.2"
       },
       "peerDependencies": {
+        "@annotorious/annotorious": "*",
+        "@annotorious/core": "*",
         "openseadragon": "^3.0.0 || ^4.0.0"
       }
     },

--- a/packages/annotorious-core/package.json
+++ b/packages/annotorious-core/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "dequal": "^2.0.3",
     "nanoevents": "^9.0.0",
-    "nanoid": "^5.0.4",
+    "nanoid": "^5.0.6",
     "uuid": "^9.0.1"
   }
 }

--- a/packages/annotorious-openseadragon/package.json
+++ b/packages/annotorious-openseadragon/package.json
@@ -46,9 +46,12 @@
     "vite-plugin-dts": "^3.7.2"
   },
   "peerDependencies": {
+    "@annotorious/core": "*",
+    "@annotorious/annotorious": "*",
     "openseadragon": "^3.0.0 || ^4.0.0"
   },
   "dependencies": {
+    "@annotorious/core": "*",
     "@annotorious/annotorious": "*",
     "@neodrag/svelte": "^2.0.3",
     "pixi.js": "^6.5.10",

--- a/packages/annotorious-openseadragon/package.json
+++ b/packages/annotorious-openseadragon/package.json
@@ -46,8 +46,6 @@
     "vite-plugin-dts": "^3.7.2"
   },
   "peerDependencies": {
-    "@annotorious/core": "*",
-    "@annotorious/annotorious": "*",
     "openseadragon": "^3.0.0 || ^4.0.0"
   },
   "dependencies": {

--- a/packages/annotorious-react-manifold/package.json
+++ b/packages/annotorious-react-manifold/package.json
@@ -39,7 +39,6 @@
     "vite-tsconfig-paths": "^4.3.1"
   },
   "peerDependencies": {
-    "@annotorious/react": "*",
     "openseadragon": "^3.0.0 || ^4.0.0",
     "react": "16.8.0 || >=17.x || >=18.x",
     "react-dom": "16.8.0 || >=17.x || >=18.x"

--- a/packages/annotorious-react-manifold/package.json
+++ b/packages/annotorious-react-manifold/package.json
@@ -43,5 +43,8 @@
     "openseadragon": "^3.0.0 || ^4.0.0",
     "react": "16.8.0 || >=17.x || >=18.x",
     "react-dom": "16.8.0 || >=17.x || >=18.x"
+  },
+  "dependencies": {
+    "@annotorious/react": "*"
   }
 }

--- a/packages/annotorious-react/package.json
+++ b/packages/annotorious-react/package.json
@@ -33,9 +33,6 @@
     "vite-tsconfig-paths": "^4.3.1"
   },
   "peerDependencies": {
-    "@annotorious/core": "*",
-    "@annotorious/annotorious": "*",
-    "@annotorious/openseadragon": "*",
     "openseadragon": "^3.0.0 || ^4.0.0",
     "react": "16.8.0 || >=17.x || >=18.x",
     "react-dom": "16.8.0 || >=17.x || >=18.x"

--- a/packages/annotorious-react/package.json
+++ b/packages/annotorious-react/package.json
@@ -33,6 +33,7 @@
     "vite-tsconfig-paths": "^4.3.1"
   },
   "peerDependencies": {
+    "@annotorious/core": "*",
     "@annotorious/annotorious": "*",
     "@annotorious/openseadragon": "*",
     "openseadragon": "^3.0.0 || ^4.0.0",
@@ -45,6 +46,8 @@
     }
   },
   "dependencies": {
+    "@annotorious/core": "*",
+    "@annotorious/annotorious": "*",
     "@annotorious/openseadragon": "*",
     "@neodrag/react": "^2.0.3"
   },

--- a/packages/annotorious-svelte/package.json
+++ b/packages/annotorious-svelte/package.json
@@ -27,9 +27,6 @@
     "vite-plugin-dts": "^3.7.2"
   },
   "peerDependencies": {
-    "@annotorious/core": "*",
-    "@annotorious/annotorious": "*",
-    "@annotorious/openseadragon": "*",
     "openseadragon": "^3.0.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/annotorious-svelte/package.json
+++ b/packages/annotorious-svelte/package.json
@@ -27,6 +27,7 @@
     "vite-plugin-dts": "^3.7.2"
   },
   "peerDependencies": {
+    "@annotorious/core": "*",
     "@annotorious/annotorious": "*",
     "@annotorious/openseadragon": "*",
     "openseadragon": "^3.0.0 || ^4.0.0"
@@ -35,6 +36,11 @@
     "openseadragon": {
       "optional": true
     }
+  },
+  "dependencies": {
+    "@annotorious/core": "*",
+    "@annotorious/annotorious": "*",
+    "@annotorious/openseadragon": "*"
   },
   "sideEffects": false
 }

--- a/packages/annotorious/package.json
+++ b/packages/annotorious/package.json
@@ -35,6 +35,9 @@
     "./annotorious.css": "./dist/annotorious.css",
     "./src": "./src/index.ts"
   },
+  "peerDependencies": {
+    "@annotorious/core": "*"
+  },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^3.0.1",
     "@tsconfig/svelte": "^5.0.2",

--- a/packages/annotorious/package.json
+++ b/packages/annotorious/package.json
@@ -35,9 +35,6 @@
     "./annotorious.css": "./dist/annotorious.css",
     "./src": "./src/index.ts"
   },
-  "peerDependencies": {
-    "@annotorious/core": "*"
-  },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^3.0.1",
     "@tsconfig/svelte": "^5.0.2",


### PR DESCRIPTION
## Issues
When I tried using the packages as standalone units I noticed that each sub-package doesn't contain an exhaustive dependencies list that are required for its functioning and building. 

---

The dependencies tree for the packages looked like this:
| Package | Dependencies |
|--------|--------|
| `@annotorious/core` | ✅ ∅ | 

---

| Package | Dependencies |
|--------|--------|
| `@annotorious/annotorious` | ⚠️ `@annotorious/core` (wasn't specified as peer)  | 

---

| Package | Dependencies |
|--------|--------|
| `@annotorious/react` | ⚠️ `@annotorious/core` (wasn't specified as peer or dependency) | 
| | ⚠️ `@annotorious/annotorious` (wasn't specified as dependency) | 
| | ✅ `@annotorious/openseadragon` | 

---

| Package | Dependencies |
|--------|--------|
| `@annotorious/openseadragon` | ⚠️ `@annotorious/core` (wasn't specified as peer or dependency) | 
| | ⚠️ `@annotorious/annotorious` (wasn't specified as peer) | 

---

| Package | Dependencies |
|--------|--------|
| `@annotorious/react-manifold` | ⚠️ `@annotorious/react` (wasn't specified as dependency) | 

---

| Package | Dependencies |
|--------|--------|
| `@annotorious/svelte` | ⚠️ `@annotorious/core` (wasn't specified as peer or dependency) | 
| | ⚠️ `@annotorious/annotorious` (wasn't specified as dependency) | 
| | ⚠️ `@annotorious/openseadragon`  (wasn't specified as dependency) | 