### PR TITLE
Added exact package versions usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5131,8 +5131,7 @@
       }
     },
     "packages/annotorious": {
-      "name": "@annotorious/annotorious",
-      "version": "3.0.0-rc.20",
+      "version": "3.0.0-rc.21",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@annotorious/core": "3.0.0-rc.19",
@@ -5154,7 +5153,7 @@
     },
     "packages/annotorious-core": {
       "name": "@annotorious/core",
-      "version": "3.0.0-rc.20",
+      "version": "3.0.0-rc.21",
       "license": "BSD-3-Clause",
       "dependencies": {
         "dequal": "^2.0.3",
@@ -5177,7 +5176,7 @@
     },
     "packages/annotorious-openseadragon": {
       "name": "@annotorious/openseadragon",
-      "version": "3.0.0-rc.20",
+      "version": "3.0.0-rc.21",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@annotorious/annotorious": "3.0.0-rc.19",
@@ -5226,7 +5225,7 @@
     },
     "packages/annotorious-react": {
       "name": "@annotorious/react",
-      "version": "3.0.0-rc.20",
+      "version": "3.0.0-rc.21",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@annotorious/annotorious": "3.0.0-rc.19",
@@ -5256,7 +5255,7 @@
     },
     "packages/annotorious-react-manifold": {
       "name": "@annotorious/react-manifold",
-      "version": "3.0.0-rc.20",
+      "version": "3.0.0-rc.21",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@annotorious/react": "3.0.0-rc.19"
@@ -5761,7 +5760,7 @@
     },
     "packages/annotorious-svelte": {
       "name": "@annotorious/svelte",
-      "version": "3.0.0-rc.20",
+      "version": "3.0.0-rc.21",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@annotorious/annotorious": "3.0.0-rc.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1190,6 +1190,15 @@
         "@pixi/sprite": "7.4.2"
       }
     },
+    "node_modules/@pixi/polyfill": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.5.10.tgz",
+      "integrity": "sha512-KDTWyr285VvPM8GGTVIZAhmxGrOlTznUGK/9kWS3GtrogwLWn41S/86Yej1gYvotVyUomCcOok33Jzahb+vX1w==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "promise-polyfill": "^8.2.0"
+      }
+    },
     "node_modules/@pixi/prepare": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.4.2.tgz",
@@ -1703,6 +1712,11 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
+    },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="
     },
     "node_modules/@types/openseadragon": {
       "version": "3.0.10",
@@ -3546,6 +3560,14 @@
       "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
       "dev": true
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
@@ -3823,6 +3845,11 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",
@@ -5108,7 +5135,7 @@
       "version": "3.0.0-rc.20",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/core": "*",
+        "@annotorious/core": "3.0.0-rc.19",
         "rbush": "^3.0.1",
         "uuid": "^9.0.1"
       },
@@ -5153,8 +5180,8 @@
       "version": "3.0.0-rc.20",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/annotorious": "*",
-        "@annotorious/core": "*",
+        "@annotorious/annotorious": "3.0.0-rc.19",
+        "@annotorious/core": "3.0.0-rc.19",
         "pixi.js": "^7.4.2",
         "uuid": "^9.0.1"
       },
@@ -5174,14 +5201,37 @@
         "openseadragon": "^3.0.0 || ^4.0.0"
       }
     },
+    "packages/annotorious-openseadragon/node_modules/@annotorious/annotorious": {
+      "version": "3.0.0-rc.19",
+      "resolved": "https://registry.npmjs.org/@annotorious/annotorious/-/annotorious-3.0.0-rc.19.tgz",
+      "integrity": "sha512-DPVW9rFihxqAjMeCSlSce8ae/FzqHg+wtWnqoYf4Z4wVJ+taY/ZYtLYMr+m+uVt7S0er0GtPhU8FEQo6JzZcHQ==",
+      "dependencies": {
+        "rbush": "^3.0.1",
+        "uuid": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@annotorious/core": "*"
+      }
+    },
+    "packages/annotorious-openseadragon/node_modules/@annotorious/core": {
+      "version": "3.0.0-rc.19",
+      "resolved": "https://registry.npmjs.org/@annotorious/core/-/core-3.0.0-rc.19.tgz",
+      "integrity": "sha512-FE74AYY8ZK+849gMCNRMZeSPftA4SQBjO9TOGcaGv64Fb2x8tCtQZhLMzpaomOfRsGCdrHXN0nyIcakTaZb5NA==",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "nanoevents": "^9.0.0",
+        "nanoid": "^5.0.4",
+        "uuid": "^9.0.1"
+      }
+    },
     "packages/annotorious-react": {
       "name": "@annotorious/react",
       "version": "3.0.0-rc.20",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/annotorious": "*",
-        "@annotorious/core": "*",
-        "@annotorious/openseadragon": "*",
+        "@annotorious/annotorious": "3.0.0-rc.19",
+        "@annotorious/core": "3.0.0-rc.19",
+        "@annotorious/openseadragon": "3.0.0-rc.19",
         "@neodrag/react": "^2.0.3"
       },
       "devDependencies": {
@@ -5209,7 +5259,7 @@
       "version": "3.0.0-rc.20",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/react": "*"
+        "@annotorious/react": "3.0.0-rc.19"
       },
       "devDependencies": {
         "@types/react": "^18.2.67",
@@ -5226,14 +5276,497 @@
         "react-dom": "16.8.0 || >=17.x || >=18.x"
       }
     },
+    "packages/annotorious-react-manifold/node_modules/@annotorious/react": {
+      "version": "3.0.0-rc.19",
+      "resolved": "https://registry.npmjs.org/@annotorious/react/-/react-3.0.0-rc.19.tgz",
+      "integrity": "sha512-EckUfqATkUbSkMqbBZHqI0l1tuo6R9A2omSAt7ODwmyurNFN0XBxcAeqpgiPdri92LzXzx21FnkWjxXnbAa3Bw==",
+      "dependencies": {
+        "@neodrag/react": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@annotorious/annotorious": "*",
+        "openseadragon": "^3.0.0 || ^4.0.0",
+        "react": "16.8.0 || >=17.x || >=18.x",
+        "react-dom": "16.8.0 || >=17.x || >=18.x"
+      },
+      "peerDependenciesMeta": {
+        "@annotorious/openseadragon": {
+          "optional": true
+        },
+        "openseadragon": {
+          "optional": true
+        }
+      }
+    },
+    "packages/annotorious-react/node_modules/@annotorious/annotorious": {
+      "version": "3.0.0-rc.19",
+      "resolved": "https://registry.npmjs.org/@annotorious/annotorious/-/annotorious-3.0.0-rc.19.tgz",
+      "integrity": "sha512-DPVW9rFihxqAjMeCSlSce8ae/FzqHg+wtWnqoYf4Z4wVJ+taY/ZYtLYMr+m+uVt7S0er0GtPhU8FEQo6JzZcHQ==",
+      "dependencies": {
+        "rbush": "^3.0.1",
+        "uuid": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@annotorious/core": "*"
+      }
+    },
+    "packages/annotorious-react/node_modules/@annotorious/core": {
+      "version": "3.0.0-rc.19",
+      "resolved": "https://registry.npmjs.org/@annotorious/core/-/core-3.0.0-rc.19.tgz",
+      "integrity": "sha512-FE74AYY8ZK+849gMCNRMZeSPftA4SQBjO9TOGcaGv64Fb2x8tCtQZhLMzpaomOfRsGCdrHXN0nyIcakTaZb5NA==",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "nanoevents": "^9.0.0",
+        "nanoid": "^5.0.4",
+        "uuid": "^9.0.1"
+      }
+    },
+    "packages/annotorious-react/node_modules/@annotorious/openseadragon": {
+      "version": "3.0.0-rc.19",
+      "resolved": "https://registry.npmjs.org/@annotorious/openseadragon/-/openseadragon-3.0.0-rc.19.tgz",
+      "integrity": "sha512-bl1MXt9cpNCrYSIgTRg3bXeUwP1Tl/vfMvjAVOyB/tOD5+F8wTEOo1E+sMFL1TSD8X8xTHAb2gWuiQXNwZp/uQ==",
+      "dependencies": {
+        "@neodrag/svelte": "^2.0.3",
+        "pixi.js": "^6.5.10",
+        "uuid": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@annotorious/annotorious": "*",
+        "openseadragon": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/accessibility": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.5.10.tgz",
+      "integrity": "sha512-URrI1H+1kjjHSyhY1QXcUZ8S3omdVTrXg5y0gndtpOhIelErBTC9NWjJfw6s0Rlmv5+x5VAitQTgw9mRiatDgw==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/app": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.5.10.tgz",
+      "integrity": "sha512-VsNHLajZ5Dbc/Zrj7iWmIl3eu6Fec+afjW/NXXezD8Sp3nTDF0bv5F+GDgN/zSc2gqIvPHyundImT7hQGBDghg==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/compressed-textures": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.5.10.tgz",
+      "integrity": "sha512-41NT5mkfam47DrkB8xMp3HUZDt7139JMB6rVNOmb3u2vm+2mdy9tzi5s9nN7bG9xgXlchxcFzytTURk+jwXVJA==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/loaders": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/constants": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.5.10.tgz",
+      "integrity": "sha512-PUF2Y9YISRu5eVrVVHhHCWpc/KmxQTg3UH8rIUs8UI9dCK41/wsPd3pEahzf7H47v7x1HCohVZcFO3XQc1bUDw=="
+    },
+    "packages/annotorious-react/node_modules/@pixi/core": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.5.10.tgz",
+      "integrity": "sha512-Gdzp5ENypyglvsh5Gv3teUZnZnmizo4xOsL+QqmWALdFlJXJwLJMVhKVThV/q/095XR6i4Ou54oshn+m4EkuFw==",
+      "dependencies": {
+        "@types/offscreencanvas": "^2019.6.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      },
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/extensions": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/runner": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/ticker": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/display": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.5.10.tgz",
+      "integrity": "sha512-NxFdDDxlbH5fQkzGHraLGoTMucW9pVgXqQm13TSmkA3NWIi/SItHL4qT2SI8nmclT9Vid1VDEBCJFAbdeuQw1Q==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/extensions": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-6.5.10.tgz",
+      "integrity": "sha512-EIUGza+E+sCy3dupuIjvRK/WyVyfSzHb5XsxRaxNrPwvG1iIUIqNqZ3owLYCo4h17fJWrj/yXVufNNtUKQccWQ=="
+    },
+    "packages/annotorious-react/node_modules/@pixi/extract": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.5.10.tgz",
+      "integrity": "sha512-hXFIc4EGs14GFfXAjT1+6mzopzCMWeXeai38/Yod3vuBXkkp8+ksen6kE09vTnB9l1IpcIaCM+XZEokuqoGX2A==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/filter-alpha": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.5.10.tgz",
+      "integrity": "sha512-GWHLJvY0QOIDRjVx0hdUff6nl/PePQg84i8XXPmANrvA+gJ/eSRTQRmQcdgInQfawENADB/oRqpcCct6IAcKpQ==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/filter-blur": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.5.10.tgz",
+      "integrity": "sha512-LJsRocVOdM9hTzZKjP+jmkfoL1nrJi5XpR0ItgRN8fflOC7A7Ln4iPe7nukbbq3H7QhZSunbygMubbO6xhThZw==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/settings": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/filter-color-matrix": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.5.10.tgz",
+      "integrity": "sha512-C2S44/EoWTrhqedLWOZTq9GZV5loEq1+MhyK9AUzEubWGMHhou1Juhn2mRZ7R6flKPCRQNKrXpStUwCAouud3Q==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/filter-displacement": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.5.10.tgz",
+      "integrity": "sha512-fbblMYyPX/hO3Tpoaa4tOBYxqp4TxjNrz6xyt15tKSVxWQElk+Tx98GJ+aaBoiHOKt8ezzHplStWoHG++JIv/w==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/math": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/filter-fxaa": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.5.10.tgz",
+      "integrity": "sha512-wbHL9UtY3g7jTyvO8JaZks6DqV8AO5c96Hfu0zfndWBPs79Ul6/sq3LD2eE+yq5vK5T2R9Sr4s54ls1JT3Sppg==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/filter-noise": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.5.10.tgz",
+      "integrity": "sha512-CX+/06NVaw3HsjipZVb7aemkca0TC8I6qfKI4lx2ugxS/6G6zkY5zqd8+nVSXW4DpUXB6eT0emwfRv6N00NvuA==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/graphics": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.5.10.tgz",
+      "integrity": "sha512-KPHGJ910fi8bRQQ+VcTIgrK+bKIm8yAQaZKPqMtm14HzHPGcES6HkgeNY1sd7m8J4aS9btm5wOSyFu0p5IzTpA==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/interaction": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.5.10.tgz",
+      "integrity": "sha512-v809pJmXA2B9dV/vdrDMUqJT+fBB/ARZli2YRmI2dPbEbkaYr8FNmxCAJnwT8o+ymTx044Ie820hn9tVrtMtfA==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/ticker": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/loaders": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.5.10.tgz",
+      "integrity": "sha512-AuK7mXBmyVsDFL9DDFPB8sqP8fwQ2NOktvu98bQuJl0/p/UeK/0OAQnF3wcf3FeBv5YGXfNHL21c2DCisjKfTg==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/math": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.5.10.tgz",
+      "integrity": "sha512-fxeu7ykVbMGxGV2S3qRTupHToeo1hdWBm8ihyURn3BMqJZe2SkZEECPd5RyvIuuNUtjRnmhkZRnF3Jsz2S+L0g=="
+    },
+    "packages/annotorious-react/node_modules/@pixi/mesh": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.5.10.tgz",
+      "integrity": "sha512-tUNPsdp5/t/yRsCmfxIcufIfbQVzgAlMNgQ1igWOkSxzhB7vlEbZ8ZLLW5tQcNyM/r7Nhjz+RoB+RD+/BCtvlA==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/mesh-extras": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.5.10.tgz",
+      "integrity": "sha512-UCG7OOPPFeikrX09haCibCMR0jPQ4UJ+4HiYiAv/3dahq5eEzBx+yAwVtxcVCjonkTf/lu5SzmHdzpsbHLx5aw==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/mesh": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/mixin-cache-as-bitmap": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.5.10.tgz",
+      "integrity": "sha512-HV4qPZt8R7uuPZf1XE5S0e3jbN4+/EqgAIkueIyK3Em+0IO1rCmIbzzYxFPxkElMUu5VvN1r4hXK846z9ITnhw==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/mixin-get-child-by-name": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.5.10.tgz",
+      "integrity": "sha512-YYd9wjnI/4aKY0H5Ij413UppVZn3YE1No2CZrNevV6WbhylsJucowY3hJihtl9mxkpwtaUIyWMjmphkbOinbzA==",
+      "peerDependencies": {
+        "@pixi/display": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/mixin-get-global-position": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.5.10.tgz",
+      "integrity": "sha512-A83gTZP9CdQAyrAvOZl1P707Q0QvIC0V8UnBAMd4GxuhMOXJtXVPCdmfPVXUrfoywgnH+/Bgimq5xhsXTf8Hzg==",
+      "peerDependencies": {
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/particle-container": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.5.10.tgz",
+      "integrity": "sha512-CCNAdYGzKoOc3FtK2kyWCNjygdHppeOEqqK189yhg3yRSsvby+HMms/cM6bLK/4Vf6mFoAy1na3w/oXpqTR2Ag==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/prepare": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.5.10.tgz",
+      "integrity": "sha512-PHMApz/GPg7IX/7+2S98criN2+Mp+fgiKpojV9cnl0SlW2zMxfAHBBi8zik9rHBgjx8X6d6bR0MG1rPtb6vSxQ==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/graphics": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/text": "6.5.10",
+        "@pixi/ticker": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/runner": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.5.10.tgz",
+      "integrity": "sha512-4HiHp6diCmigJT/DSbnqQP62OfWKmZB7zPWMdV1AEdr4YT1QxzXAW1wHg7dkoEfyTHqZKl0tm/zcqKq/iH7tMA=="
+    },
+    "packages/annotorious-react/node_modules/@pixi/settings": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.5.10.tgz",
+      "integrity": "sha512-ypAS5L7pQ2Qb88yQK72bXtc7sD8OrtLWNXdZ/gnw5kwSWCFaOSoqhKqJCXrR5DQtN98+RQefwbEAmMvqobhFyw==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/sprite": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.5.10.tgz",
+      "integrity": "sha512-UiK+8LgM9XQ/SBDKjRgZ8WggdOSlFRXqiWjEZVmNkiyU8HvXeFzWPRhpc8RR1zDwAUhZWKtMhF8X/ba9m+z2lg==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/sprite-animated": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.5.10.tgz",
+      "integrity": "sha512-x1kayucAqpVbNk+j+diC/7sQGQsAl6NCH1J2/EEaiQjlV3GOx1MXS9Tft1N1Y1y7otbg1XsnBd60/Yzcp05pxA==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/ticker": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/sprite-tiling": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.5.10.tgz",
+      "integrity": "sha512-lDFcPuwExrdJhli+WmjPivChjeCG6NiRl36iQ8n2zVi/MYVv9qfKCA6IdU7HBWk1AZdsg6KUTpwfmVLUI+qz3w==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/spritesheet": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.5.10.tgz",
+      "integrity": "sha512-7uOZ1cYyYtPb0ZEgXV1SZ8ujtluZNY0TL5z3+Qc8cgGGZK/MaWG7N6Wf+uR4BR2x8FLNwcyN5IjbQDKCpblrmg==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/loaders": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/text": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.5.10.tgz",
+      "integrity": "sha512-ikwkonLJ+6QmEVW8Ji9fS5CjrKNbU4mHzYuwRQas/VJQuSWgd0myCcaw6ZbF1oSfQe70HgbNOR0sH8Q3Com0qg==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/text-bitmap": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.5.10.tgz",
+      "integrity": "sha512-g/iFIMGp6Pfi0BvX6Ykp48Z6JXVgKOrc7UCIR9CM21wYcCiQGqtdFwstV236xk6/D8NToUtSOcifhtQ28dVTdQ==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/loaders": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/mesh": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/text": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/ticker": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.5.10.tgz",
+      "integrity": "sha512-UqX1XYtzqFSirmTOy8QAK4Ccg4KkIZztrBdRPKwFSOEiKAJoGDCSBmyQBo/9aYQKGObbNnrJ7Hxv3/ucg3/1GA==",
+      "peerDependencies": {
+        "@pixi/extensions": "6.5.10",
+        "@pixi/settings": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/@pixi/utils": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.5.10.tgz",
+      "integrity": "sha512-4f4qDMmAz9IoSAe08G2LAxUcEtG9jSdudfsMQT2MG+OpfToirboE6cNoO0KnLCvLzDVE/mfisiQ9uJbVA9Ssdw==",
+      "dependencies": {
+        "@types/earcut": "^2.1.0",
+        "earcut": "^2.2.4",
+        "eventemitter3": "^3.1.0",
+        "url": "^0.11.0"
+      },
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/settings": "6.5.10"
+      }
+    },
+    "packages/annotorious-react/node_modules/eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+    },
+    "packages/annotorious-react/node_modules/pixi.js": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.5.10.tgz",
+      "integrity": "sha512-Z2mjeoISml2iuVwT1e/BQwERYM2yKoiR08ZdGrg8y5JjeuVptfTrve4DbPMRN/kEDodesgQZGV/pFv0fE9Q2SA==",
+      "dependencies": {
+        "@pixi/accessibility": "6.5.10",
+        "@pixi/app": "6.5.10",
+        "@pixi/compressed-textures": "6.5.10",
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/extensions": "6.5.10",
+        "@pixi/extract": "6.5.10",
+        "@pixi/filter-alpha": "6.5.10",
+        "@pixi/filter-blur": "6.5.10",
+        "@pixi/filter-color-matrix": "6.5.10",
+        "@pixi/filter-displacement": "6.5.10",
+        "@pixi/filter-fxaa": "6.5.10",
+        "@pixi/filter-noise": "6.5.10",
+        "@pixi/graphics": "6.5.10",
+        "@pixi/interaction": "6.5.10",
+        "@pixi/loaders": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/mesh": "6.5.10",
+        "@pixi/mesh-extras": "6.5.10",
+        "@pixi/mixin-cache-as-bitmap": "6.5.10",
+        "@pixi/mixin-get-child-by-name": "6.5.10",
+        "@pixi/mixin-get-global-position": "6.5.10",
+        "@pixi/particle-container": "6.5.10",
+        "@pixi/polyfill": "6.5.10",
+        "@pixi/prepare": "6.5.10",
+        "@pixi/runner": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/sprite-animated": "6.5.10",
+        "@pixi/sprite-tiling": "6.5.10",
+        "@pixi/spritesheet": "6.5.10",
+        "@pixi/text": "6.5.10",
+        "@pixi/text-bitmap": "6.5.10",
+        "@pixi/ticker": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      }
+    },
     "packages/annotorious-svelte": {
       "name": "@annotorious/svelte",
       "version": "3.0.0-rc.20",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/annotorious": "*",
-        "@annotorious/core": "*",
-        "@annotorious/openseadragon": "*",
+        "@annotorious/annotorious": "3.0.0-rc.19",
+        "@annotorious/core": "3.0.0-rc.19",
+        "@annotorious/openseadragon": "3.0.0-rc.19",
         "@neodrag/svelte": "^2.0.3"
       },
       "devDependencies": {
@@ -5255,6 +5788,478 @@
         "openseadragon": {
           "optional": true
         }
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@annotorious/annotorious": {
+      "version": "3.0.0-rc.19",
+      "resolved": "https://registry.npmjs.org/@annotorious/annotorious/-/annotorious-3.0.0-rc.19.tgz",
+      "integrity": "sha512-DPVW9rFihxqAjMeCSlSce8ae/FzqHg+wtWnqoYf4Z4wVJ+taY/ZYtLYMr+m+uVt7S0er0GtPhU8FEQo6JzZcHQ==",
+      "dependencies": {
+        "rbush": "^3.0.1",
+        "uuid": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@annotorious/core": "*"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@annotorious/core": {
+      "version": "3.0.0-rc.19",
+      "resolved": "https://registry.npmjs.org/@annotorious/core/-/core-3.0.0-rc.19.tgz",
+      "integrity": "sha512-FE74AYY8ZK+849gMCNRMZeSPftA4SQBjO9TOGcaGv64Fb2x8tCtQZhLMzpaomOfRsGCdrHXN0nyIcakTaZb5NA==",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "nanoevents": "^9.0.0",
+        "nanoid": "^5.0.4",
+        "uuid": "^9.0.1"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@annotorious/openseadragon": {
+      "version": "3.0.0-rc.19",
+      "resolved": "https://registry.npmjs.org/@annotorious/openseadragon/-/openseadragon-3.0.0-rc.19.tgz",
+      "integrity": "sha512-bl1MXt9cpNCrYSIgTRg3bXeUwP1Tl/vfMvjAVOyB/tOD5+F8wTEOo1E+sMFL1TSD8X8xTHAb2gWuiQXNwZp/uQ==",
+      "dependencies": {
+        "@neodrag/svelte": "^2.0.3",
+        "pixi.js": "^6.5.10",
+        "uuid": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@annotorious/annotorious": "*",
+        "openseadragon": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/accessibility": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.5.10.tgz",
+      "integrity": "sha512-URrI1H+1kjjHSyhY1QXcUZ8S3omdVTrXg5y0gndtpOhIelErBTC9NWjJfw6s0Rlmv5+x5VAitQTgw9mRiatDgw==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/app": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.5.10.tgz",
+      "integrity": "sha512-VsNHLajZ5Dbc/Zrj7iWmIl3eu6Fec+afjW/NXXezD8Sp3nTDF0bv5F+GDgN/zSc2gqIvPHyundImT7hQGBDghg==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/compressed-textures": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.5.10.tgz",
+      "integrity": "sha512-41NT5mkfam47DrkB8xMp3HUZDt7139JMB6rVNOmb3u2vm+2mdy9tzi5s9nN7bG9xgXlchxcFzytTURk+jwXVJA==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/loaders": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/constants": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.5.10.tgz",
+      "integrity": "sha512-PUF2Y9YISRu5eVrVVHhHCWpc/KmxQTg3UH8rIUs8UI9dCK41/wsPd3pEahzf7H47v7x1HCohVZcFO3XQc1bUDw=="
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/core": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.5.10.tgz",
+      "integrity": "sha512-Gdzp5ENypyglvsh5Gv3teUZnZnmizo4xOsL+QqmWALdFlJXJwLJMVhKVThV/q/095XR6i4Ou54oshn+m4EkuFw==",
+      "dependencies": {
+        "@types/offscreencanvas": "^2019.6.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      },
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/extensions": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/runner": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/ticker": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/display": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.5.10.tgz",
+      "integrity": "sha512-NxFdDDxlbH5fQkzGHraLGoTMucW9pVgXqQm13TSmkA3NWIi/SItHL4qT2SI8nmclT9Vid1VDEBCJFAbdeuQw1Q==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/extensions": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-6.5.10.tgz",
+      "integrity": "sha512-EIUGza+E+sCy3dupuIjvRK/WyVyfSzHb5XsxRaxNrPwvG1iIUIqNqZ3owLYCo4h17fJWrj/yXVufNNtUKQccWQ=="
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/extract": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.5.10.tgz",
+      "integrity": "sha512-hXFIc4EGs14GFfXAjT1+6mzopzCMWeXeai38/Yod3vuBXkkp8+ksen6kE09vTnB9l1IpcIaCM+XZEokuqoGX2A==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/filter-alpha": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.5.10.tgz",
+      "integrity": "sha512-GWHLJvY0QOIDRjVx0hdUff6nl/PePQg84i8XXPmANrvA+gJ/eSRTQRmQcdgInQfawENADB/oRqpcCct6IAcKpQ==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/filter-blur": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.5.10.tgz",
+      "integrity": "sha512-LJsRocVOdM9hTzZKjP+jmkfoL1nrJi5XpR0ItgRN8fflOC7A7Ln4iPe7nukbbq3H7QhZSunbygMubbO6xhThZw==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/settings": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/filter-color-matrix": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.5.10.tgz",
+      "integrity": "sha512-C2S44/EoWTrhqedLWOZTq9GZV5loEq1+MhyK9AUzEubWGMHhou1Juhn2mRZ7R6flKPCRQNKrXpStUwCAouud3Q==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/filter-displacement": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.5.10.tgz",
+      "integrity": "sha512-fbblMYyPX/hO3Tpoaa4tOBYxqp4TxjNrz6xyt15tKSVxWQElk+Tx98GJ+aaBoiHOKt8ezzHplStWoHG++JIv/w==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/math": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/filter-fxaa": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.5.10.tgz",
+      "integrity": "sha512-wbHL9UtY3g7jTyvO8JaZks6DqV8AO5c96Hfu0zfndWBPs79Ul6/sq3LD2eE+yq5vK5T2R9Sr4s54ls1JT3Sppg==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/filter-noise": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.5.10.tgz",
+      "integrity": "sha512-CX+/06NVaw3HsjipZVb7aemkca0TC8I6qfKI4lx2ugxS/6G6zkY5zqd8+nVSXW4DpUXB6eT0emwfRv6N00NvuA==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/graphics": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.5.10.tgz",
+      "integrity": "sha512-KPHGJ910fi8bRQQ+VcTIgrK+bKIm8yAQaZKPqMtm14HzHPGcES6HkgeNY1sd7m8J4aS9btm5wOSyFu0p5IzTpA==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/interaction": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.5.10.tgz",
+      "integrity": "sha512-v809pJmXA2B9dV/vdrDMUqJT+fBB/ARZli2YRmI2dPbEbkaYr8FNmxCAJnwT8o+ymTx044Ie820hn9tVrtMtfA==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/ticker": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/loaders": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.5.10.tgz",
+      "integrity": "sha512-AuK7mXBmyVsDFL9DDFPB8sqP8fwQ2NOktvu98bQuJl0/p/UeK/0OAQnF3wcf3FeBv5YGXfNHL21c2DCisjKfTg==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/math": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.5.10.tgz",
+      "integrity": "sha512-fxeu7ykVbMGxGV2S3qRTupHToeo1hdWBm8ihyURn3BMqJZe2SkZEECPd5RyvIuuNUtjRnmhkZRnF3Jsz2S+L0g=="
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/mesh": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.5.10.tgz",
+      "integrity": "sha512-tUNPsdp5/t/yRsCmfxIcufIfbQVzgAlMNgQ1igWOkSxzhB7vlEbZ8ZLLW5tQcNyM/r7Nhjz+RoB+RD+/BCtvlA==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/mesh-extras": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.5.10.tgz",
+      "integrity": "sha512-UCG7OOPPFeikrX09haCibCMR0jPQ4UJ+4HiYiAv/3dahq5eEzBx+yAwVtxcVCjonkTf/lu5SzmHdzpsbHLx5aw==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/mesh": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/mixin-cache-as-bitmap": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.5.10.tgz",
+      "integrity": "sha512-HV4qPZt8R7uuPZf1XE5S0e3jbN4+/EqgAIkueIyK3Em+0IO1rCmIbzzYxFPxkElMUu5VvN1r4hXK846z9ITnhw==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/mixin-get-child-by-name": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.5.10.tgz",
+      "integrity": "sha512-YYd9wjnI/4aKY0H5Ij413UppVZn3YE1No2CZrNevV6WbhylsJucowY3hJihtl9mxkpwtaUIyWMjmphkbOinbzA==",
+      "peerDependencies": {
+        "@pixi/display": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/mixin-get-global-position": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.5.10.tgz",
+      "integrity": "sha512-A83gTZP9CdQAyrAvOZl1P707Q0QvIC0V8UnBAMd4GxuhMOXJtXVPCdmfPVXUrfoywgnH+/Bgimq5xhsXTf8Hzg==",
+      "peerDependencies": {
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/particle-container": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.5.10.tgz",
+      "integrity": "sha512-CCNAdYGzKoOc3FtK2kyWCNjygdHppeOEqqK189yhg3yRSsvby+HMms/cM6bLK/4Vf6mFoAy1na3w/oXpqTR2Ag==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/prepare": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.5.10.tgz",
+      "integrity": "sha512-PHMApz/GPg7IX/7+2S98criN2+Mp+fgiKpojV9cnl0SlW2zMxfAHBBi8zik9rHBgjx8X6d6bR0MG1rPtb6vSxQ==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/graphics": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/text": "6.5.10",
+        "@pixi/ticker": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/runner": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.5.10.tgz",
+      "integrity": "sha512-4HiHp6diCmigJT/DSbnqQP62OfWKmZB7zPWMdV1AEdr4YT1QxzXAW1wHg7dkoEfyTHqZKl0tm/zcqKq/iH7tMA=="
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/settings": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.5.10.tgz",
+      "integrity": "sha512-ypAS5L7pQ2Qb88yQK72bXtc7sD8OrtLWNXdZ/gnw5kwSWCFaOSoqhKqJCXrR5DQtN98+RQefwbEAmMvqobhFyw==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/sprite": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.5.10.tgz",
+      "integrity": "sha512-UiK+8LgM9XQ/SBDKjRgZ8WggdOSlFRXqiWjEZVmNkiyU8HvXeFzWPRhpc8RR1zDwAUhZWKtMhF8X/ba9m+z2lg==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/sprite-animated": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.5.10.tgz",
+      "integrity": "sha512-x1kayucAqpVbNk+j+diC/7sQGQsAl6NCH1J2/EEaiQjlV3GOx1MXS9Tft1N1Y1y7otbg1XsnBd60/Yzcp05pxA==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/ticker": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/sprite-tiling": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.5.10.tgz",
+      "integrity": "sha512-lDFcPuwExrdJhli+WmjPivChjeCG6NiRl36iQ8n2zVi/MYVv9qfKCA6IdU7HBWk1AZdsg6KUTpwfmVLUI+qz3w==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/spritesheet": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.5.10.tgz",
+      "integrity": "sha512-7uOZ1cYyYtPb0ZEgXV1SZ8ujtluZNY0TL5z3+Qc8cgGGZK/MaWG7N6Wf+uR4BR2x8FLNwcyN5IjbQDKCpblrmg==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/loaders": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/text": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.5.10.tgz",
+      "integrity": "sha512-ikwkonLJ+6QmEVW8Ji9fS5CjrKNbU4mHzYuwRQas/VJQuSWgd0myCcaw6ZbF1oSfQe70HgbNOR0sH8Q3Com0qg==",
+      "peerDependencies": {
+        "@pixi/core": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/text-bitmap": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.5.10.tgz",
+      "integrity": "sha512-g/iFIMGp6Pfi0BvX6Ykp48Z6JXVgKOrc7UCIR9CM21wYcCiQGqtdFwstV236xk6/D8NToUtSOcifhtQ28dVTdQ==",
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/loaders": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/mesh": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/text": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/ticker": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.5.10.tgz",
+      "integrity": "sha512-UqX1XYtzqFSirmTOy8QAK4Ccg4KkIZztrBdRPKwFSOEiKAJoGDCSBmyQBo/9aYQKGObbNnrJ7Hxv3/ucg3/1GA==",
+      "peerDependencies": {
+        "@pixi/extensions": "6.5.10",
+        "@pixi/settings": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/@pixi/utils": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.5.10.tgz",
+      "integrity": "sha512-4f4qDMmAz9IoSAe08G2LAxUcEtG9jSdudfsMQT2MG+OpfToirboE6cNoO0KnLCvLzDVE/mfisiQ9uJbVA9Ssdw==",
+      "dependencies": {
+        "@types/earcut": "^2.1.0",
+        "earcut": "^2.2.4",
+        "eventemitter3": "^3.1.0",
+        "url": "^0.11.0"
+      },
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10",
+        "@pixi/settings": "6.5.10"
+      }
+    },
+    "packages/annotorious-svelte/node_modules/eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+    },
+    "packages/annotorious-svelte/node_modules/pixi.js": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.5.10.tgz",
+      "integrity": "sha512-Z2mjeoISml2iuVwT1e/BQwERYM2yKoiR08ZdGrg8y5JjeuVptfTrve4DbPMRN/kEDodesgQZGV/pFv0fE9Q2SA==",
+      "dependencies": {
+        "@pixi/accessibility": "6.5.10",
+        "@pixi/app": "6.5.10",
+        "@pixi/compressed-textures": "6.5.10",
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/extensions": "6.5.10",
+        "@pixi/extract": "6.5.10",
+        "@pixi/filter-alpha": "6.5.10",
+        "@pixi/filter-blur": "6.5.10",
+        "@pixi/filter-color-matrix": "6.5.10",
+        "@pixi/filter-displacement": "6.5.10",
+        "@pixi/filter-fxaa": "6.5.10",
+        "@pixi/filter-noise": "6.5.10",
+        "@pixi/graphics": "6.5.10",
+        "@pixi/interaction": "6.5.10",
+        "@pixi/loaders": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/mesh": "6.5.10",
+        "@pixi/mesh-extras": "6.5.10",
+        "@pixi/mixin-cache-as-bitmap": "6.5.10",
+        "@pixi/mixin-get-child-by-name": "6.5.10",
+        "@pixi/mixin-get-global-position": "6.5.10",
+        "@pixi/particle-container": "6.5.10",
+        "@pixi/polyfill": "6.5.10",
+        "@pixi/prepare": "6.5.10",
+        "@pixi/runner": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/sprite-animated": "6.5.10",
+        "@pixi/sprite-tiling": "6.5.10",
+        "@pixi/spritesheet": "6.5.10",
+        "@pixi/text": "6.5.10",
+        "@pixi/text-bitmap": "6.5.10",
+        "@pixi/ticker": "6.5.10",
+        "@pixi/utils": "6.5.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      }
+    },
+    "packages/annotorious/node_modules/@annotorious/core": {
+      "version": "3.0.0-rc.19",
+      "resolved": "https://registry.npmjs.org/@annotorious/core/-/core-3.0.0-rc.19.tgz",
+      "integrity": "sha512-FE74AYY8ZK+849gMCNRMZeSPftA4SQBjO9TOGcaGv64Fb2x8tCtQZhLMzpaomOfRsGCdrHXN0nyIcakTaZb5NA==",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "nanoevents": "^9.0.0",
+        "nanoid": "^5.0.4",
+        "uuid": "^9.0.1"
       }
     }
   }

--- a/packages/annotorious-core/package.json
+++ b/packages/annotorious-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@annotorious/core",
-  "version": "3.0.0-rc.20",
+  "version": "3.0.0-rc.21",
   "description": "Annotorious core types and functions",
   "author": "Rainer Simon",
   "license": "BSD-3-Clause",

--- a/packages/annotorious-openseadragon/package.json
+++ b/packages/annotorious-openseadragon/package.json
@@ -49,8 +49,8 @@
     "openseadragon": "^3.0.0 || ^4.0.0"
   },
   "dependencies": {
-    "@annotorious/core": "*",
-    "@annotorious/annotorious": "*",
+    "@annotorious/core": "3.0.0-rc.19",
+    "@annotorious/annotorious": "3.0.0-rc.19",
     "pixi.js": "^7.4.2",
     "uuid": "^9.0.1"
   }

--- a/packages/annotorious-openseadragon/package.json
+++ b/packages/annotorious-openseadragon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@annotorious/openseadragon",
-  "version": "3.0.0-rc.20",
+  "version": "3.0.0-rc.21",
   "description": "Annotorious for OpenSeadragon",
   "author": "Rainer Simon",
   "license": "BSD-3-Clause",

--- a/packages/annotorious-react-manifold/package.json
+++ b/packages/annotorious-react-manifold/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@annotorious/react-manifold",
-  "version": "3.0.0-rc.20",
+  "version": "3.0.0-rc.21",
   "description": "A utility to manage multiple parallel Annotorious instances more efficiently",
   "author": "Rainer Simon",
   "license": "BSD-3-Clause",

--- a/packages/annotorious-react-manifold/package.json
+++ b/packages/annotorious-react-manifold/package.json
@@ -44,6 +44,6 @@
     "react-dom": "16.8.0 || >=17.x || >=18.x"
   },
   "dependencies": {
-    "@annotorious/react": "*"
+    "@annotorious/react": "3.0.0-rc.19"
   }
 }

--- a/packages/annotorious-react/package.json
+++ b/packages/annotorious-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@annotorious/react",
-  "version": "3.0.0-rc.20",
+  "version": "3.0.0-rc.21",
   "description": "Annotorious React bindings",
   "author": "Rainer Simon",
   "license": "BSD-3-Clause",

--- a/packages/annotorious-react/package.json
+++ b/packages/annotorious-react/package.json
@@ -43,9 +43,9 @@
     }
   },
   "dependencies": {
-    "@annotorious/core": "*",
-    "@annotorious/annotorious": "*",
-    "@annotorious/openseadragon": "*",
+    "@annotorious/core": "3.0.0-rc.19",
+    "@annotorious/annotorious": "3.0.0-rc.19",
+    "@annotorious/openseadragon": "3.0.0-rc.19",
     "@neodrag/react": "^2.0.3"
   },
   "sideEffects": false

--- a/packages/annotorious-svelte/package.json
+++ b/packages/annotorious-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@annotorious/svelte",
-  "version": "3.0.0-rc.20",
+  "version": "3.0.0-rc.21",
   "description": "Annotorious Svelte bindings",
   "author": "Rainer Simon",
   "license": "BSD-3-Clause",

--- a/packages/annotorious-svelte/package.json
+++ b/packages/annotorious-svelte/package.json
@@ -35,9 +35,9 @@
     }
   },
   "dependencies": {
-    "@annotorious/annotorious": "*",
-    "@annotorious/core": "*",
-    "@annotorious/openseadragon": "*",
+    "@annotorious/annotorious": "3.0.0-rc.19",
+    "@annotorious/core": "3.0.0-rc.19",
+    "@annotorious/openseadragon": "3.0.0-rc.19",
     "@neodrag/svelte": "^2.0.3"
   },
   "sideEffects": false

--- a/packages/annotorious/package.json
+++ b/packages/annotorious/package.json
@@ -48,7 +48,7 @@
     "vitest": "^1.4.0"
   },
   "dependencies": {
-    "@annotorious/core": "*",
+    "@annotorious/core": "3.0.0-rc.19",
     "rbush": "^3.0.1",
     "uuid": "^9.0.1"
   }

--- a/packages/annotorious/package.json
+++ b/packages/annotorious/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@annotorious/annotorious",
-  "version": "3.0.0-rc.20",
+  "version": "3.0.0-rc.21",
   "description": "Add image annotation functionality to any web page with a few lines of JavaScript",
   "author": "Rainer Simon",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Fixes the wildcard bug that doesn't allow to build the project, see https://github.com/annotorious/annotorious/pull/386#issuecomment-2014975694. Specifically added usage of the `.19` version that doesn't have the "*"