### PR TITLE
Excluded mandatory dependencies from bundling for ES modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1630,9 +1630,9 @@
       }
     },
     "node_modules/@tsconfig/svelte": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.2.tgz",
-      "integrity": "sha512-BRbo1fOtyVbhfLyuCWw6wAWp+U8UQle+ZXu84MYYWzYSEB28dyfnRBIE99eoG+qdAC0po6L2ScIEivcT07UaMA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.3.tgz",
+      "integrity": "sha512-Ms0t9K0oxioSb0lrZ5NRysx0nE/KsojYOG+db9v6wSaU/+P37vc0WRmh1QE1c8IAtTniD4yEhffGQuTKF8uaPw==",
       "dev": true
     },
     "node_modules/@types/argparse": {
@@ -5114,7 +5114,7 @@
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^3.0.2",
-        "@tsconfig/svelte": "^5.0.2",
+        "@tsconfig/svelte": "^5.0.3",
         "@types/rbush": "^3.0.3",
         "jsdom": "^24.0.0",
         "svelte": "^4.2.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1729,9 +1729,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.67",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.67.tgz",
-      "integrity": "sha512-vkIE2vTIMHQ/xL0rgmuoECBCkZFZeHr49HeWSc24AptMbNRo7pwSBvj73rlJJs9fGKj0koS+V7kQB1jHS0uCgw==",
+      "version": "18.2.70",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.70.tgz",
+      "integrity": "sha512-hjlM2hho2vqklPhopNkXkdkeq6Lv8WSZTpr7956zY+3WS5cfYUewtCzsJLsbW5dEv3lfSeQ4W14ZFeKC437JRQ==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -4677,9 +4677,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.3.tgz",
-      "integrity": "sha512-+i1oagbvkVIhEy9TnEV+fgXsng13nZM90JQbrcPrf6DvW2mXARlz+DK7DLiDP+qeKoD1FCVx/1SpFL1CLq9Mhw==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.6.tgz",
+      "integrity": "sha512-FPtnxFlSIKYjZ2eosBQamz4CbyrTizbZ3hnGJlh/wMtCrlp1Hah6AzBLjGI5I2urTfNnpovpHdrL6YRuBOPnCA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.20.1",
@@ -5108,7 +5108,7 @@
       "version": "3.0.0-rc.21",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/core": "^3.0.0-rc.20",
+        "@annotorious/core": "^3.0.0-rc.21",
         "rbush": "^3.0.1",
         "uuid": "^9.0.1"
       },
@@ -5153,8 +5153,8 @@
       "version": "3.0.0-rc.21",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/annotorious": "^3.0.0-rc.20",
-        "@annotorious/core": "^3.0.0-rc.20",
+        "@annotorious/annotorious": "^3.0.0-rc.21",
+        "@annotorious/core": "^3.0.0-rc.21",
         "pixi.js": "^7.4.2",
         "uuid": "^9.0.1"
       },
@@ -5179,17 +5179,17 @@
       "version": "3.0.0-rc.21",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/annotorious": "^3.0.0-rc.20",
-        "@annotorious/core": "^3.0.0-rc.20",
-        "@annotorious/openseadragon": "^3.0.0-rc.20",
+        "@annotorious/annotorious": "^3.0.0-rc.21",
+        "@annotorious/core": "^3.0.0-rc.21",
+        "@annotorious/openseadragon": "^3.0.0-rc.21",
         "@neodrag/react": "^2.0.3"
       },
       "devDependencies": {
-        "@types/react": "^18.2.67",
+        "@types/react": "^18.2.70",
         "@types/react-dom": "^18.2.22",
         "@vitejs/plugin-react": "^4.2.1",
         "typescript": "^5.3.3",
-        "vite": "^5.2.2",
+        "vite": "^5.2.6",
         "vite-plugin-dts": "^3.7.3",
         "vite-tsconfig-paths": "^4.3.2"
       },
@@ -5218,7 +5218,7 @@
         "vite-tsconfig-paths": "^4.3.2"
       },
       "peerDependencies": {
-        "@annotorious/react": "^3.0.0-rc.20",
+        "@annotorious/react": "^3.0.0-rc.21",
         "openseadragon": "^3.0.0 || ^4.0.0",
         "react": "16.8.0 || >=17.x || >=18.x",
         "react-dom": "16.8.0 || >=17.x || >=18.x"
@@ -5229,9 +5229,9 @@
       "version": "3.0.0-rc.21",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@annotorious/annotorious": "^3.0.0-rc.20",
-        "@annotorious/core": "^3.0.0-rc.20",
-        "@annotorious/openseadragon": "^3.0.0-rc.20",
+        "@annotorious/annotorious": "^3.0.0-rc.21",
+        "@annotorious/core": "^3.0.0-rc.21",
+        "@annotorious/openseadragon": "^3.0.0-rc.21",
         "@neodrag/svelte": "^2.0.3"
       },
       "devDependencies": {

--- a/packages/annotorious-openseadragon/package.json
+++ b/packages/annotorious-openseadragon/package.json
@@ -49,8 +49,8 @@
     "openseadragon": "^3.0.0 || ^4.0.0"
   },
   "dependencies": {
-    "@annotorious/core": "^3.0.0-rc.20",
-    "@annotorious/annotorious": "^3.0.0-rc.20",
+    "@annotorious/core": "^3.0.0-rc.21",
+    "@annotorious/annotorious": "^3.0.0-rc.21",
     "pixi.js": "^7.4.2",
     "uuid": "^9.0.1"
   }

--- a/packages/annotorious-openseadragon/vite.config.js
+++ b/packages/annotorious-openseadragon/vite.config.js
@@ -8,11 +8,7 @@ import * as packageJson from './package.json';
 export default defineConfig({
   plugins: [
     svelte({ preprocess: sveltePreprocess() }),
-    dts({
-      insertTypesEntry: true,
-      include: ['./src/'],
-      entryRoot: './src'
-    })
+    dts({ insertTypesEntry: true, include: ['./src/'], entryRoot: './src' })
   ],
   server: {
     open: '/test/index.html'
@@ -28,7 +24,8 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
-        ...Object.keys(packageJson.peerDependencies)
+        ...Object.keys(packageJson.peerDependencies),
+        /@annotorious\/(core|annotorious)/
       ],
       output: {
         assetFileNames: 'annotorious-openseadragon.[ext]',

--- a/packages/annotorious-openseadragon/vite.config.js
+++ b/packages/annotorious-openseadragon/vite.config.js
@@ -25,7 +25,8 @@ export default defineConfig({
     rollupOptions: {
       external: [
         ...Object.keys(packageJson.peerDependencies),
-        /@annotorious\/(core|annotorious)/
+        '@annotorious/core',
+        '@annotorious/annotorious'
       ],
       output: {
         assetFileNames: 'annotorious-openseadragon.[ext]',

--- a/packages/annotorious-openseadragon/vite.config.js
+++ b/packages/annotorious-openseadragon/vite.config.js
@@ -23,16 +23,10 @@ export default defineConfig({
         format === 'umd' ? `annotorious-openseadragon.js` : `annotorious-openseadragon.es.js` 
     },
     rollupOptions: {
-      external: [
-        ...Object.keys(packageJson.peerDependencies),
-        '@annotorious/core',
-        '@annotorious/annotorious'
-      ],
+      external: Object.keys(packageJson.peerDependencies),
       output: {
         assetFileNames: 'annotorious-openseadragon.[ext]',
         globals: {
-          '@annotorious/core': 'AnnotoriousCore',
-          '@annotorious/annotorious': 'Annotorious',
           openseadragon: 'OpenSeadragon'
         }
       }

--- a/packages/annotorious-openseadragon/vite.config.js
+++ b/packages/annotorious-openseadragon/vite.config.js
@@ -30,6 +30,7 @@ export default defineConfig({
       output: {
         assetFileNames: 'annotorious-openseadragon.[ext]',
         globals: {
+          '@annotorious/core': 'AnnotoriousCore',
           '@annotorious/annotorious': 'Annotorious',
           openseadragon: 'OpenSeadragon'
         }

--- a/packages/annotorious-react-manifold/package.json
+++ b/packages/annotorious-react-manifold/package.json
@@ -39,7 +39,7 @@
     "vite-tsconfig-paths": "^4.3.2"
   },
   "peerDependencies": {
-    "@annotorious/react": "^3.0.0-rc.20",
+    "@annotorious/react": "^3.0.0-rc.21",
     "openseadragon": "^3.0.0 || ^4.0.0",
     "react": "16.8.0 || >=17.x || >=18.x",
     "react-dom": "16.8.0 || >=17.x || >=18.x"

--- a/packages/annotorious-react-manifold/vite.config.js
+++ b/packages/annotorious-react-manifold/vite.config.js
@@ -29,10 +29,7 @@ export default defineConfig({
       ],
       output: {
         preserveModules: true,
-        assetFileNames: 'annotorious-react-manifold.[ext]',
-        globals: {
-          react: 'React'
-        }
+        assetFileNames: 'annotorious-react-manifold.[ext]'
       }
     },
     sourcemap: true

--- a/packages/annotorious-react/package.json
+++ b/packages/annotorious-react/package.json
@@ -24,11 +24,11 @@
     "./annotorious-react.css": "./dist/annotorious-react.css"
   },
   "devDependencies": {
-    "@types/react": "^18.2.67",
+    "@types/react": "^18.2.70",
     "@types/react-dom": "^18.2.22",
     "@vitejs/plugin-react": "^4.2.1",
     "typescript": "^5.3.3",
-    "vite": "^5.2.2",
+    "vite": "^5.2.6",
     "vite-plugin-dts": "^3.7.3",
     "vite-tsconfig-paths": "^4.3.2"
   },
@@ -43,9 +43,9 @@
     }
   },
   "dependencies": {
-    "@annotorious/core": "^3.0.0-rc.20",
-    "@annotorious/annotorious": "^3.0.0-rc.20",
-    "@annotorious/openseadragon": "^3.0.0-rc.20",
+    "@annotorious/core": "^3.0.0-rc.21",
+    "@annotorious/annotorious": "^3.0.0-rc.21",
+    "@annotorious/openseadragon": "^3.0.0-rc.21",
     "@neodrag/react": "^2.0.3"
   },
   "sideEffects": false

--- a/packages/annotorious-react/vite.config.js
+++ b/packages/annotorious-react/vite.config.js
@@ -25,13 +25,15 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
-        ...Object.keys(packageJson.peerDependencies)
+        ...Object.keys(packageJson.peerDependencies),
+        /@annotorious\/(core|annotorious|openseadragon)/
       ],
       output: {
         preserveModules: true,
         assetFileNames: 'annotorious-react.[ext]',
         globals: {
           react: 'React',
+          '@annotorious/annotorious': 'Annotorious',
           openseadragon: 'OpenSeadragon'
         }
       }

--- a/packages/annotorious-react/vite.config.js
+++ b/packages/annotorious-react/vite.config.js
@@ -26,7 +26,9 @@ export default defineConfig({
     rollupOptions: {
       external: [
         ...Object.keys(packageJson.peerDependencies),
-        /@annotorious\/(core|annotorious|openseadragon)/
+        '@annotorious/core',
+        '@annotorious/annotorious',
+        '@annotorious/openseadragon'
       ],
       output: {
         preserveModules: true,

--- a/packages/annotorious-react/vite.config.js
+++ b/packages/annotorious-react/vite.config.js
@@ -30,12 +30,7 @@ export default defineConfig({
       ],
       output: {
         preserveModules: true,
-        assetFileNames: 'annotorious-react.[ext]',
-        globals: {
-          react: 'React',
-          '@annotorious/annotorious': 'Annotorious',
-          openseadragon: 'OpenSeadragon'
-        }
+        assetFileNames: 'annotorious-react.[ext]'
       }
     },
     sourcemap: true

--- a/packages/annotorious-svelte/package.json
+++ b/packages/annotorious-svelte/package.json
@@ -35,8 +35,8 @@
     }
   },
   "dependencies": {
-    "@annotorious/annotorious": "^3.0.0-rc.21",
     "@annotorious/core": "^3.0.0-rc.21",
+    "@annotorious/annotorious": "^3.0.0-rc.21",
     "@annotorious/openseadragon": "^3.0.0-rc.21",
     "@neodrag/svelte": "^2.0.3"
   },

--- a/packages/annotorious-svelte/package.json
+++ b/packages/annotorious-svelte/package.json
@@ -35,9 +35,9 @@
     }
   },
   "dependencies": {
-    "@annotorious/annotorious": "^3.0.0-rc.20",
-    "@annotorious/core": "^3.0.0-rc.20",
-    "@annotorious/openseadragon": "^3.0.0-rc.20",
+    "@annotorious/annotorious": "^3.0.0-rc.21",
+    "@annotorious/core": "^3.0.0-rc.21",
+    "@annotorious/openseadragon": "^3.0.0-rc.21",
     "@neodrag/svelte": "^2.0.3"
   },
   "sideEffects": false

--- a/packages/annotorious-svelte/vite.config.js
+++ b/packages/annotorious-svelte/vite.config.js
@@ -24,11 +24,15 @@ export default defineConfig({
       fileName: (format) => `annotorious-svelte.${format}.js`
     },
     rollupOptions: {
-      external: [...Object.keys(packageJson.peerDependencies)],
+      external: [
+        ...Object.keys(packageJson.peerDependencies),
+        /@annotorious\/(core|annotorious|openseadragon)/
+      ],
       output: {
         preserveModules: true,
         assetFileNames: 'annotorious-svelte.[ext]',
         globals: {
+          '@annotorious/annotorious': 'Annotorious',
           openseadragon: 'OpenSeadragon'
         }
       }

--- a/packages/annotorious-svelte/vite.config.js
+++ b/packages/annotorious-svelte/vite.config.js
@@ -26,7 +26,9 @@ export default defineConfig({
     rollupOptions: {
       external: [
         ...Object.keys(packageJson.peerDependencies),
-        /@annotorious\/(core|annotorious|openseadragon)/
+        '@annotorious/core',
+        '@annotorious/annotorious',
+        '@annotorious/openseadragon'
       ],
       output: {
         preserveModules: true,

--- a/packages/annotorious-svelte/vite.config.js
+++ b/packages/annotorious-svelte/vite.config.js
@@ -30,11 +30,7 @@ export default defineConfig({
       ],
       output: {
         preserveModules: true,
-        assetFileNames: 'annotorious-svelte.[ext]',
-        globals: {
-          '@annotorious/annotorious': 'Annotorious',
-          openseadragon: 'OpenSeadragon'
-        }
+        assetFileNames: 'annotorious-svelte.[ext]'
       }
     },
     sourcemap: true

--- a/packages/annotorious/package.json
+++ b/packages/annotorious/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^3.0.2",
-    "@tsconfig/svelte": "^5.0.2",
+    "@tsconfig/svelte": "^5.0.3",
     "@types/rbush": "^3.0.3",
     "jsdom": "^24.0.0",
     "svelte": "^4.2.12",

--- a/packages/annotorious/package.json
+++ b/packages/annotorious/package.json
@@ -48,7 +48,7 @@
     "vitest": "^1.4.0"
   },
   "dependencies": {
-    "@annotorious/core": "^3.0.0-rc.20",
+    "@annotorious/core": "^3.0.0-rc.21",
     "rbush": "^3.0.1",
     "uuid": "^9.0.1"
   }

--- a/packages/annotorious/vite.config.js
+++ b/packages/annotorious/vite.config.js
@@ -6,11 +6,7 @@ import dts from 'vite-plugin-dts';
 export default defineConfig({
   plugins: [
     svelte({ preprocess: sveltePreprocess() }),
-    dts({ 
-      insertTypesEntry: true,
-      include: ['./src/'],
-      entryRoot: './src'
-    })
+    dts({ insertTypesEntry: true, include: ['./src/'], entryRoot: './src' })
   ],
   server: {
     open: '/test/index.html'
@@ -21,14 +17,15 @@ export default defineConfig({
       entry: './src/index.ts',
       name: 'Annotorious',
       formats: ['es', 'umd'],
-      fileName: (format) => 
-        format === 'umd' ? `annotorious.js` : `annotorious.es.js` 
+      fileName: (format) =>
+        format === 'umd' ? `annotorious.js` : `annotorious.es.js`
     },
     rollupOptions: {
-      output: {
-        assetFileNames: 'annotorious.[ext]'
-      },
-      external: [ 'test/*' ]
+      output: { assetFileNames: 'annotorious.[ext]' },
+      external: [
+				'@annotorious/core',
+				'test/*'
+      ]
     }
   }
 });

--- a/packages/annotorious/vite.config.js
+++ b/packages/annotorious/vite.config.js
@@ -21,11 +21,16 @@ export default defineConfig({
         format === 'umd' ? `annotorious.js` : `annotorious.es.js`
     },
     rollupOptions: {
-      output: { assetFileNames: 'annotorious.[ext]' },
       external: [
-				'@annotorious/core',
-				'test/*'
-      ]
+        '@annotorious/core',
+        'test/*'
+      ],
+      output: {
+        assetFileNames: 'annotorious.[ext]',
+        globals: {
+          '@annotorious/core': 'AnnotoriousCore'
+        }
+      }
     }
   }
 });

--- a/packages/annotorious/vite.config.js
+++ b/packages/annotorious/vite.config.js
@@ -21,15 +21,9 @@ export default defineConfig({
         format === 'umd' ? `annotorious.js` : `annotorious.es.js`
     },
     rollupOptions: {
-      external: [
-        '@annotorious/core',
-        'test/*'
-      ],
+      external: ['test/*'],
       output: {
-        assetFileNames: 'annotorious.[ext]',
-        globals: {
-          '@annotorious/core': 'AnnotoriousCore'
-        }
+        assetFileNames: 'annotorious.[ext]'
       }
     }
   }


### PR DESCRIPTION
## Issue
When working on the consuming app for the `A9S` + `R6O` packages I noticed that the libraries code is [included in the final bundle twice](https://github.com/recogito/text-annotator-js/pull/75#issuecomment-2018235214) 👁️👁️ 
I found it to be an error-prone approach, especially if the React Context gets duplicated and the hooks lose a "single source of truth" instance.

## Changes Made
I excluded the mandatory dependencies from the bundling of the packages. It gives us a few benefits:
1. The dependencies are guaranteed to be installed by the consuming app/package. Therefore, the A9S should expect that those dependencies will be available to consume
2. There will be no duplication of the code in the final bundle of the consuming app/package
3. Smaller package size to publish

## Next Steps
Apply the same treatment of the R6O dependencies