### PR TITLE
Remove ImageAnnotator reexport from annotorious-react

### DIFF
--- a/packages/annotorious-react/src/index.ts
+++ b/packages/annotorious-react/src/index.ts
@@ -60,7 +60,6 @@ export type {
   FragmentSelector,
   ImageAnnotator as AnnotoriousImageAnnotator,
   ImageAnnotation,
-  ImageAnnotator,
   ImageAnnotatorState,
   Polygon,
   PolygonGeometry,


### PR DESCRIPTION
I think this fixes #392 .

I haven't fully tested it by building and using modified package, but making the same edit in my node_modules seems to clear it up.