### PR TITLE
Added baseline `Sorter` helper definition

### DIFF
--- a/packages/annotorious-core/src/model/Annotator.ts
+++ b/packages/annotorious-core/src/model/Annotator.ts
@@ -1,11 +1,12 @@
 import type { Annotation } from './Annotation';
 import type { User } from './User';
-import type { PresenceProvider } from '../presence/PresenceProvider';
+import type { PresenceProvider } from '../presence';
 import { Origin, type HoverState, type SelectionState, type Store, type UndoStack, type ViewportState } from '../state';
-import type { LifecycleEvents } from '../lifecycle/LifecycleEvents';
+import type { LifecycleEvents } from '../lifecycle';
 import { parseAll, type FormatAdapter } from './FormatAdapter';
 import type { DrawingStyleExpression } from './DrawingStyle';
 import type { Filter } from './Filter';
+import type { Sorter } from './Sorter';
 
 /**
  * Base annotator interface
@@ -43,6 +44,8 @@ export interface Annotator<I extends Annotation = Annotation, E extends unknown 
   setAnnotations(annotations: E[], replace?: boolean): void;
 
   setFilter(filter: Filter | undefined): void;
+
+  setSorter(sorter: Sorter | undefined): void;
 
   setPresenceProvider?(provider: PresenceProvider): void;
 

--- a/packages/annotorious-core/src/model/Sorter.ts
+++ b/packages/annotorious-core/src/model/Sorter.ts
@@ -1,0 +1,3 @@
+import type { Annotation } from './Annotation';
+
+export type Sorter<T extends Annotation = Annotation> = (a: T, b: T) => number;

--- a/packages/annotorious-core/src/model/Sorter.ts
+++ b/packages/annotorious-core/src/model/Sorter.ts
@@ -1,3 +1,10 @@
 import type { Annotation } from './Annotation';
 
 export type Sorter<T extends Annotation = Annotation> = (a: T, b: T) => number;
+
+export const DEFAULT_ANNOTATION_SORTER: Sorter = (a, b) => {
+  const { target: { created: createdA } } = a;
+  const { target: { created: createdB } } = b;
+
+  return (createdA?.getTime() || 0) - (createdB?.getTime() || 0);
+};

--- a/packages/annotorious-core/src/model/index.ts
+++ b/packages/annotorious-core/src/model/index.ts
@@ -3,6 +3,7 @@ export * from './AnnotationState';
 export * from './Annotator';
 export * from './DrawingStyle';
 export * from './Filter';
+export * from './Sorter';
 export * from './FormatAdapter';
 export * from './User';
 export * from './W3CAnnotation';

--- a/packages/annotorious/src/Annotorious.ts
+++ b/packages/annotorious/src/Annotorious.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponent } from 'svelte';
 import { PointerSelectAction } from '@annotorious/core';
-import type { Annotator, DrawingStyleExpression, Filter, User } from '@annotorious/core';
+import type { Annotator, DrawingStyleExpression, Filter, Sorter, User } from '@annotorious/core';
 import { createAnonymousGuest, createBaseAnnotator, createLifecyleObserver, createUndoStack } from '@annotorious/core';
 import { registerEditor } from './annotation/editors';
 import { getTool, registerTool, listDrawingTools, type DrawingTool } from './annotation/tools';
@@ -138,10 +138,14 @@ export const createImageAnnotator = <E extends unknown = ImageAnnotation>(
 
   const setDrawingEnabled = (enabled: boolean) =>
     annotationLayer.$set({ drawingEnabled: enabled });
-  
-  const setFilter = (filter: Filter) => {
+
+  const setFilter = (_filter: Filter) => {
     console.warn('Filter not implemented yet');
-  }
+  };
+
+  const setSorter = (_sorter: Sorter) => {
+    console.warn('Sorter not implemented yet');
+  };
 
   const setStyle = (style: DrawingStyleExpression<ImageAnnotation> | undefined) =>
     annotationLayer.$set({ style });
@@ -169,6 +173,7 @@ export const createImageAnnotator = <E extends unknown = ImageAnnotation>(
     setDrawingEnabled,
     setDrawingTool,
     setFilter,
+    setSorter,
     setStyle,
     setTheme,
     setUser,

--- a/packages/annotorious/src/index.ts
+++ b/packages/annotorious/src/index.ts
@@ -19,6 +19,7 @@ export type {
   Color,
   DrawingStyle,
   Filter,
+  Sorter,
   FormatAdapter,
   HoverState,
   LifecycleEvents,


### PR DESCRIPTION
## Issue
#### See - https://github.com/recogito/text-annotator-js/issues/94

In this PR I added a baseline type definition and implementation for the `Sorter` helper. 
It follows the `Filter` definition structure.