### PR TITLE
#419 Selection `event` generalization

### DIFF
--- a/docs/getting-started-image.md
+++ b/docs/getting-started-image.md
@@ -61,15 +61,15 @@ anno.on('createAnnotation', function(annotation) {
 
 ## AnnotoriousOpts
 
-| Arg                   | Type                                            | Default       |
-|-----------------------|-------------------------------------------------|---------------|
-| `adapter`             | [FormatAdapter](#formatadapter)                 | -             |
-| `autoSave`            | `boolean`                                       | `false`       |
-| `drawingEnabled`      | `boolean`                                       | `true`        |
-| `drawingMode`         | `'click'` \| `'drag'`                           | `'drag'`      |
-| `pointerSelectAction` | [PointerSelectDefinition](#pointerselectaction) | `'EDIT'`      |
-| `style`               | [StyleDefinition](#style)                       | -             |
-| `theme`               | `'dark'` \| `'light'` \| `'auto'`               | `'light'`     |
+| Arg              | Type                                    | Default       |
+|------------------|-----------------------------------------|---------------|
+| `adapter`        | [FormatAdapter](#formatadapter)         | -             |
+| `autoSave`       | `boolean`                               | `false`       |
+| `drawingEnabled` | `boolean`                               | `true`        |
+| `drawingMode`    | `'click'` \| `'drag'`                   | `'drag'`      |
+| `selectAction`   | [SelectActionDefinition](#selectaction) | `'EDIT'`      |
+| `style`          | [StyleDefinition](#style)               | -             |
+| `theme`          | `'dark'` \| `'light'` \| `'auto'`       | `'light'`     |
 
 ## FormatAdapter
 
@@ -85,9 +85,9 @@ const anno = createImageAnnotator('sample-image', {
 });
 ```
 
-## PointerSelectAction
+## SelectAction
 
-The `pointerSelectAction` prop controls the behavior when a user clicks or taps on an annotation. Valid values for pointerSelectAction are `EDIT`, `SELECT`, and `NONE`.
+The `selectAction` prop controls the behavior when a user clicks or taps on an annotation. Valid values for selectAction are `EDIT`, `SELECT`, and `NONE`.
 
 - __EDIT__ makes the annotation editable, allowing the users to modify its shape.
 
@@ -95,34 +95,34 @@ The `pointerSelectAction` prop controls the behavior when a user clicks or taps 
 
 - __NONE__ renders the annotation inert. Clicking on it will have no effect.
 
-You can directly assign one of these values to pointerSelectAction. For example:
+You can directly assign one of these values to selectAction. For example:
 
 ```ts
-import { createImageAnnotator, PointerSelectionAction, W3CImageFormat } from '@annotorious/annotorious';
+import { createImageAnnotator, SelectAction, W3CImageFormat } from '@annotorious/annotorious';
 
 const anno = createImageAnnotator('sample-image', {
-  pointerSelectAction: PointerSelectAction.EDIT
+  selectAction: SelectAction.EDIT
 });
 ```
 
-Alternatively, you can use a function that dynamically determines the `pointerSelectAction`` based on annotation properties or other conditions:
+Alternatively, you can use a function that dynamically determines the `selectAction`` based on annotation properties or other conditions:
 
 ```ts
-import { createImageAnnotator, PointerSelectionAction, W3CImageFormat } from '@annotorious/annotorious';
+import { createImageAnnotator, SelectAction, W3CImageFormat } from '@annotorious/annotorious';
 
 const dynamicSelectAction = (annotation: Annotation) => {
   const isMine = annotation.target.creator.id == 'me';
-  return isMine ? PointerSelectAction.EDIT : PointerSelectAction.SELECT;
+  return isMine ? SelectAction.EDIT : SelectAction.SELECT;
 };
 
 const anno = createImageAnnotator('sample-image', {
-  pointerSelectAction: dynamicSelectAction
+  selectAction: dynamicSelectAction
 });
 ```
 
 __Note:__
 
-For TypeScript users, the valid values for `pointerSelectAction` are provided as enums for type safety. However, in plain JavaScript, you can use the string values ('EDIT', 'SELECT', 'NONE') directly.
+For TypeScript users, the valid values for `selectAction` are provided as enums for type safety. However, in plain JavaScript, you can use the string values ('EDIT', 'SELECT', 'NONE') directly.
 
 ## Style
 

--- a/docs/getting-started-image.md
+++ b/docs/getting-started-image.md
@@ -61,15 +61,15 @@ anno.on('createAnnotation', function(annotation) {
 
 ## AnnotoriousOpts
 
-| Arg              | Type                                    | Default       |
-|------------------|-----------------------------------------|---------------|
-| `adapter`        | [FormatAdapter](#formatadapter)         | -             |
-| `autoSave`       | `boolean`                               | `false`       |
-| `drawingEnabled` | `boolean`                               | `true`        |
-| `drawingMode`    | `'click'` \| `'drag'`                   | `'drag'`      |
-| `selectAction`   | [SelectActionDefinition](#selectaction) | `'EDIT'`      |
-| `style`          | [StyleDefinition](#style)               | -             |
-| `theme`          | `'dark'` \| `'light'` \| `'auto'`       | `'light'`     |
+| Arg                | Type                                            | Default       |
+|--------------------|-------------------------------------------------|---------------|
+| `adapter`          | [FormatAdapter](#formatadapter)                 | -             |
+| `autoSave`         | `boolean`                                       | `false`       |
+| `drawingEnabled`   | `boolean`                                       | `true`        |
+| `drawingMode`      | `'click'` \| `'drag'`                           | `'drag'`      |
+| `userSelectAction` | [UserSelectActionDefinition](#userselectaction) | `'EDIT'`      |
+| `style`            | [StyleDefinition](#style)                       | -             |
+| `theme`            | `'dark'` \| `'light'` \| `'auto'`               | `'light'`     |
 
 ## FormatAdapter
 
@@ -85,9 +85,9 @@ const anno = createImageAnnotator('sample-image', {
 });
 ```
 
-## SelectAction
+## UserSelectAction
 
-The `selectAction` prop controls the behavior when a user clicks or taps on an annotation. Valid values for selectAction are `EDIT`, `SELECT`, and `NONE`.
+The `userSelectAction` prop controls the behavior when a user clicks or taps on an annotation. Valid values for selectAction are `EDIT`, `SELECT`, and `NONE`.
 
 - __EDIT__ makes the annotation editable, allowing the users to modify its shape.
 
@@ -95,34 +95,34 @@ The `selectAction` prop controls the behavior when a user clicks or taps on an a
 
 - __NONE__ renders the annotation inert. Clicking on it will have no effect.
 
-You can directly assign one of these values to selectAction. For example:
+You can directly assign one of these values to userSelectAction. For example:
 
 ```ts
-import { createImageAnnotator, SelectAction, W3CImageFormat } from '@annotorious/annotorious';
+import { createImageAnnotator, UserSelectAction, W3CImageFormat } from '@annotorious/annotorious';
 
 const anno = createImageAnnotator('sample-image', {
-  selectAction: SelectAction.EDIT
+  userSelectAction: SelectAction.EDIT
 });
 ```
 
-Alternatively, you can use a function that dynamically determines the `selectAction`` based on annotation properties or other conditions:
+Alternatively, you can use a function that dynamically determines the `userSelectAction`` based on annotation properties or other conditions:
 
 ```ts
-import { createImageAnnotator, SelectAction, W3CImageFormat } from '@annotorious/annotorious';
+import { createImageAnnotator, UserSelectAction, W3CImageFormat } from '@annotorious/annotorious';
 
 const dynamicSelectAction = (annotation: Annotation) => {
   const isMine = annotation.target.creator.id == 'me';
-  return isMine ? SelectAction.EDIT : SelectAction.SELECT;
+  return isMine ? UserSelectAction.EDIT : UserSelectAction.SELECT;
 };
 
 const anno = createImageAnnotator('sample-image', {
-  selectAction: dynamicSelectAction
+  userSelectAction: dynamicSelectAction
 });
 ```
 
 __Note:__
 
-For TypeScript users, the valid values for `selectAction` are provided as enums for type safety. However, in plain JavaScript, you can use the string values ('EDIT', 'SELECT', 'NONE') directly.
+For TypeScript users, the valid values for `userSelectAction` are provided as enums for type safety. However, in plain JavaScript, you can use the string values ('EDIT', 'SELECT', 'NONE') directly.
 
 ## Style
 

--- a/docs/react/image-annotator.md
+++ b/docs/react/image-annotator.md
@@ -37,18 +37,18 @@ This component provides context for all parts of an annotation layer on an image
 #### ImageAnnotator
 This component wraps an image component and applies an annotation layer to it.
 
-| Prop             | Type                                     | Default       |
-|------------------|------------------------------------------|---------------|
-| `adapter`        | [FormatAdapter](#formatadapter)          | -             |
-| `autoSave`       | `boolean`                                | `false`       |
-| `drawingEnabled` | `boolean`                                | `true`        |
-| `drawingMode`    | `'click'` \| `'drag'`                    | `'drag'`      |
-| `filter`         | [FilterDefinition](#filter)              | -             |
-| `selectAction`   | [selectDefinition](#selectaction)        | `'EDIT'`      |
-| `style`          | [StyleDefinition](#style)                | -             |
-| `theme`          | `'dark'` \| `'light'` \| `'auto'`        | `'light'`     |
-| `tool`           | `'rectangle'` \| `'light'`               | `'rectangle'` |
- 
+| Prop               | Type                                            | Default       |
+|--------------------|-------------------------------------------------|---------------|
+| `adapter`          | [FormatAdapter](#formatadapter)                 | -             |
+| `autoSave`         | `boolean`                                       | `false`       |
+| `drawingEnabled`   | `boolean`                                       | `true`        |
+| `drawingMode`      | `'click'` \| `'drag'`                           | `'drag'`      |
+| `filter`           | [FilterDefinition](#filter)                     | -             |
+| `userSelectAction` | [UserSelectActionDefinition](#userselectaction) | `'EDIT'`      |
+| `style`            | [StyleDefinition](#style)                       | -             |
+| `theme`            | `'dark'` \| `'light'` \| `'auto'`               | `'light'`     |
+| `tool`             | `'rectangle'` \| `'light'`                      | `'rectangle'` |
+
 #### FormatAdapter
 
 The `adapter` prop is an optional object that introduces crosswalk functionality between Annotorious' internal annotation data model and different standards. This allows seamless integration of external annotation standards, such as the [W3C Web Annotation standard](https://www.w3.org/TR/annotation-model/), into Annotorious. The adapter will handle the process of parsing and serializing annotations between Annotorious' internal format and the chosen external standard for you. 
@@ -82,9 +82,9 @@ const showImportantFilter = (annotation: Annotation) => {
 </ImageAnnotator>;
 ```
 
-#### selectAction
+#### UserSelectAction
 
-The `selectAction` prop controls the behavior when a user clicks or taps on an annotation. Valid values for selectAction are `EDIT`, `SELECT`, and `NONE`.
+The `userSelectAction` prop controls the behavior when a user clicks or taps on an annotation. Valid values for userSelectAction are `EDIT`, `SELECT`, and `NONE`.
 
 - __EDIT__ makes the annotation editable, allowing the users to modify its shape.
 
@@ -92,36 +92,36 @@ The `selectAction` prop controls the behavior when a user clicks or taps on an a
 
 - __NONE__ renders the annotation inert. Clicking on it will have no effect.
 
-You can directly assign one of these values to selectAction. For example:
+You can directly assign one of these values to userSelectAction. For example:
 
 ```tsx
-import { SelectAction } from '@annotorious/react'; 
+import { UserSelectAction } from '@annotorious/react'; 
 
-<ImageAnnotator selectAction={SelectAction.EDIT}>
+<ImageAnnotator userSelectAction={UserSelectAction.EDIT}>
   <img src="example.jpg" />
 </ImageAnnotator>
 ```
 
-Alternatively, you can use a function that dynamically determines the `selectAction`` based on annotation properties or other conditions:
+Alternatively, you can use a function that dynamically determines the `userSelectAction`` based on annotation properties or other conditions:
 
 ```tsx
 const dynamicSelectAction = (annotation: Annotation) => {
   const isMine = annotation.target.creator.id == 'me';
-  return isMine ? SelectAction.EDIT : SelectAction.SELECT;
+  return isMine ? UserSelectAction.EDIT : UserSelectAction.SELECT;
 };
 
-<ImageAnnotator selectAction={dynamicSelectAction}>
+<ImageAnnotator userSelectAction={dynamicSelectAction}>
   <img src="example.jpg" />
 </ImageAnnotator>
 ```
 
 __Note:__
 
-For TypeScript users, the valid values for `selectAction` are provided as enums for type safety. However, in plain JavaScript, you can use the string values ('EDIT', 'SELECT', 'NONE') directly.
+For TypeScript users, the valid values for `userSelectAction` are provided as enums for type safety. However, in plain JavaScript, you can use the string values ('EDIT', 'SELECT', 'NONE') directly.
 
 ```ts 
 // TypeScript
-const action: SelectAction = SelectAction.EDIT;
+const action: UserSelectAction = UserSelectAction.EDIT;
 
 // JavaScript
 const action = 'EDIT';

--- a/docs/react/image-annotator.md
+++ b/docs/react/image-annotator.md
@@ -37,17 +37,17 @@ This component provides context for all parts of an annotation layer on an image
 #### ImageAnnotator
 This component wraps an image component and applies an annotation layer to it.
 
-| Prop                  | Type                                            | Default       |
-|-----------------------|-------------------------------------------------|---------------|
-| `adapter`             | [FormatAdapter](#formatadapter)                 | -             |
-| `autoSave`            | `boolean`                                       | `false`       |
-| `drawingEnabled`      | `boolean`                                       | `true`        |
-| `drawingMode`         | `'click'` \| `'drag'`                           | `'drag'`      |
-| `filter`              | [FilterDefinition](#filter)                     | -             |
-| `pointerSelectAction` | [PointerSelectDefinition](#pointerselectaction) | `'EDIT'`      |
-| `style`               | [StyleDefinition](#style)                       | -             |
-| `theme`               | `'dark'` \| `'light'` \| `'auto'`               | `'light'`     |
-| `tool`                | `'rectangle'` \| `'light'`                      | `'rectangle'` |
+| Prop             | Type                                     | Default       |
+|------------------|------------------------------------------|---------------|
+| `adapter`        | [FormatAdapter](#formatadapter)          | -             |
+| `autoSave`       | `boolean`                                | `false`       |
+| `drawingEnabled` | `boolean`                                | `true`        |
+| `drawingMode`    | `'click'` \| `'drag'`                    | `'drag'`      |
+| `filter`         | [FilterDefinition](#filter)              | -             |
+| `selectAction`   | [selectDefinition](#selectaction)        | `'EDIT'`      |
+| `style`          | [StyleDefinition](#style)                | -             |
+| `theme`          | `'dark'` \| `'light'` \| `'auto'`        | `'light'`     |
+| `tool`           | `'rectangle'` \| `'light'`               | `'rectangle'` |
  
 #### FormatAdapter
 
@@ -82,9 +82,9 @@ const showImportantFilter = (annotation: Annotation) => {
 </ImageAnnotator>;
 ```
 
-#### PointerSelectAction
+#### selectAction
 
-The `pointerSelectAction` prop controls the behavior when a user clicks or taps on an annotation. Valid values for pointerSelectAction are `EDIT`, `SELECT`, and `NONE`.
+The `selectAction` prop controls the behavior when a user clicks or taps on an annotation. Valid values for selectAction are `EDIT`, `SELECT`, and `NONE`.
 
 - __EDIT__ makes the annotation editable, allowing the users to modify its shape.
 
@@ -92,36 +92,36 @@ The `pointerSelectAction` prop controls the behavior when a user clicks or taps 
 
 - __NONE__ renders the annotation inert. Clicking on it will have no effect.
 
-You can directly assign one of these values to pointerSelectAction. For example:
+You can directly assign one of these values to selectAction. For example:
 
 ```tsx
-import { PointerSelectionAction } from '@annotorious/react'; 
+import { SelectAction } from '@annotorious/react'; 
 
-<ImageAnnotator pointerSelectAction={PointerSelectAction.EDIT}>
+<ImageAnnotator selectAction={SelectAction.EDIT}>
   <img src="example.jpg" />
 </ImageAnnotator>
 ```
 
-Alternatively, you can use a function that dynamically determines the `pointerSelectAction`` based on annotation properties or other conditions:
+Alternatively, you can use a function that dynamically determines the `selectAction`` based on annotation properties or other conditions:
 
 ```tsx
 const dynamicSelectAction = (annotation: Annotation) => {
   const isMine = annotation.target.creator.id == 'me';
-  return isMine ? PointerSelectAction.EDIT : PointerSelectAction.SELECT;
+  return isMine ? SelectAction.EDIT : SelectAction.SELECT;
 };
 
-<ImageAnnotator pointerSelectAction={dynamicSelectAction}>
+<ImageAnnotator selectAction={dynamicSelectAction}>
   <img src="example.jpg" />
 </ImageAnnotator>
 ```
 
 __Note:__
 
-For TypeScript users, the valid values for `pointerSelectAction` are provided as enums for type safety. However, in plain JavaScript, you can use the string values ('EDIT', 'SELECT', 'NONE') directly.
+For TypeScript users, the valid values for `selectAction` are provided as enums for type safety. However, in plain JavaScript, you can use the string values ('EDIT', 'SELECT', 'NONE') directly.
 
 ```ts 
 // TypeScript
-const action: PointerSelectAction = PointerSelectAction.EDIT;
+const action: SelectAction = SelectAction.EDIT;
 
 // JavaScript
 const action = 'EDIT';

--- a/packages/annotorious-core/src/lifecycle/Lifecycle.ts
+++ b/packages/annotorious-core/src/lifecycle/Lifecycle.ts
@@ -194,7 +194,7 @@ export const createLifecycleObserver = <I extends Annotation, E extends unknown>
 
   const onUndoOrRedo = (undo: boolean) => (changes: ChangeSet<I>) => {
     // Undo/redo of created/delete will cause lifecycle events automatically,
-    // but we need to handle udpates specifically!
+    // but we need to handle updates specifically!
     const { updated } = changes;
 
     if (undo)

--- a/packages/annotorious-core/src/state/Selection.ts
+++ b/packages/annotorious-core/src/state/Selection.ts
@@ -2,11 +2,13 @@ import { writable } from 'svelte/store';
 import type {  Annotation } from '../model';
 import type { Store } from './Store';
    
-export type Selection = {
+export interface Selection {
 
   selected: { id: string, editable?: boolean }[],
 
   pointerEvent?: PointerEvent;
+
+  [key: string]: any; // Allow for additional properties to be added by plugins
 
 }
 

--- a/packages/annotorious-core/src/state/Selection.ts
+++ b/packages/annotorious-core/src/state/Selection.ts
@@ -87,30 +87,29 @@ export const createSelectionState = <T extends Annotation>(
   }
 
   const removeFromSelection = (ids: string[]) => {
-    if (currentSelection.selected.length === 0)
-      return false;
+    if (isEmpty()) return false;
 
     const { selected } = currentSelection;
 
     // Checks which of the given annotations are actually in the selection
-    const toRemove = selected.filter(({ id  }) => ids.includes(id))
-
-    if (toRemove.length > 0)
+    const shouldRemove = selected.some(({ id }) => ids.includes(id));
+    if (shouldRemove)
       set({ selected: selected.filter(({ id }) => !ids.includes(id)) });
   }
 
   // Track store delete and update events
-  store.observe(({ changes }) =>
-    removeFromSelection((changes.deleted || []).map(a => a.id)));
+  store.observe(
+    ({ changes }) => removeFromSelection((changes.deleted || []).map(a => a.id))
+  );
 
-  return { 
-    clear, 
-    clickSelect, 
+  return {
+    clear,
+    clickSelect,
     get selected() { return currentSelection ? [...currentSelection.selected ] : null},
     get pointerEvent() { return currentSelection ? currentSelection.pointerEvent : null },
-    isEmpty, 
-    isSelected, 
-    setSelected, 
+    isEmpty,
+    isSelected,
+    setSelected,
     subscribe,
     set
   };

--- a/packages/annotorious-core/src/state/Selection.ts
+++ b/packages/annotorious-core/src/state/Selection.ts
@@ -68,11 +68,12 @@ export const createSelectionState = <T extends Annotation>(
     const ids = Array.isArray(idOrIds) ? idOrIds : [idOrIds];
 
     // Remove invalid
-    const annotations = 
-      ids.map(id => store.getAnnotation(id)!).filter(Boolean); 
+    const annotations = ids
+      .map(id => store.getAnnotation(id))
+      .filter((a): a is T => Boolean(a));
 
-    set({ 
-      selected: annotations.map(annotation => { 
+    set({
+      selected: annotations.map(annotation => {
         // If editable is not set, use default behavior
         const isEditable = editable === undefined
           ? onPointerSelect(annotation, selectAction) === PointerSelectAction.EDIT
@@ -81,7 +82,7 @@ export const createSelectionState = <T extends Annotation>(
         return { id: annotation.id, editable: isEditable }
       })
     });
-    
+
     if (annotations.length !== ids.length)
       console.warn('Invalid selection', idOrIds);
   }

--- a/packages/annotorious-core/src/state/Selection.ts
+++ b/packages/annotorious-core/src/state/Selection.ts
@@ -111,7 +111,8 @@ export const createSelectionState = <T extends Annotation>(
     isEmpty, 
     isSelected, 
     setSelected, 
-    subscribe 
+    subscribe,
+    set
   };
 
 }

--- a/packages/annotorious-core/src/state/Selection.ts
+++ b/packages/annotorious-core/src/state/Selection.ts
@@ -14,7 +14,7 @@ export interface Selection {
 
 export type SelectionState<T extends Annotation> = ReturnType<typeof createSelectionState<T>>;
 
-export enum SelectAction {
+export enum UserSelectAction {
 
   EDIT = 'EDIT', // Make annotation target(s) editable on pointer select
 
@@ -28,7 +28,7 @@ const EMPTY: Selection = { selected: [] };
 
 export const createSelectionState = <T extends Annotation>(
   store: Store<T>,
-  selectAction: SelectAction | ((a: T) => SelectAction) = SelectAction.EDIT
+  userSelectAction: UserSelectAction | ((a: T) => UserSelectAction) = UserSelectAction.EDIT
 ) => {
   const { subscribe, set } = writable<Selection>(EMPTY);
 
@@ -56,12 +56,12 @@ export const createSelectionState = <T extends Annotation>(
       return;
     }
 
-    const action = onSelect(annotation, selectAction);
+    const action = onUserSelect(annotation, userSelectAction);
     switch (action) {
-      case SelectAction.EDIT:
+      case UserSelectAction.EDIT:
         set({ selected: [{ id, editable: true }], event });
         break;
-      case SelectAction.SELECT:
+      case UserSelectAction.SELECT:
         set({ selected: [{ id }], event });
         break;
       default:
@@ -81,7 +81,7 @@ export const createSelectionState = <T extends Annotation>(
       selected: annotations.map(annotation => {
         // If editable is not set, use default behavior
         const isEditable = editable === undefined
-          ? onSelect(annotation, selectAction) === SelectAction.EDIT
+          ? onUserSelect(annotation, userSelectAction) === UserSelectAction.EDIT
           : editable;
 
         return { id: annotation.id, editable: isEditable }
@@ -127,7 +127,7 @@ export const createSelectionState = <T extends Annotation>(
 
 }
 
-export const onSelect = <T extends Annotation>(
+export const onUserSelect = <T extends Annotation>(
   annotation: T,
-  action?: SelectAction | ((a: T) => SelectAction)
-): SelectAction => (typeof action === 'function') ? action(annotation) : (action || SelectAction.EDIT);
+  action?: UserSelectAction | ((a: T) => UserSelectAction)
+): UserSelectAction => (typeof action === 'function') ? action(annotation) : (action || UserSelectAction.EDIT);

--- a/packages/annotorious-core/src/state/Selection.ts
+++ b/packages/annotorious-core/src/state/Selection.ts
@@ -49,7 +49,7 @@ export const createSelectionState = <T extends Annotation>(
   }
 
   // TODO enable CTRL select
-  const eventSelect = (id: string, event: Selection['event']) => {
+  const userSelect = (id: string, event?: Selection['event']) => {
     const annotation = store.getAnnotation(id);
     if (!annotation) {
       console.warn('Invalid selection: ' + id);
@@ -112,7 +112,7 @@ export const createSelectionState = <T extends Annotation>(
   return {
     isSelected,
     setSelected,
-    eventSelect,
+    userSelect,
     get selected() {
       return currentSelection ? [...currentSelection.selected] : null;
     },

--- a/packages/annotorious-core/test/state/Selection.test.ts
+++ b/packages/annotorious-core/test/state/Selection.test.ts
@@ -34,11 +34,11 @@ describe('createSelectionState', () => {
     selectionState = createSelectionState(store);
   });
 
-  describe('clickSelect', () => {
+  describe('userSelect', () => {
 
     it('should set the selection to an array containing the clicked annotation', () => {
       // @ts-ignore
-      selectionState.clickSelect(testAnnotation1.id, undefined);
+      selectionState.userSelect(testAnnotation1.id);
       expect(selectionState.isEmpty()).toBe(false);
       expect(selectionState.isSelected(testAnnotation1)).toBe(true);
     });

--- a/packages/annotorious-openseadragon/src/Annotorious.ts
+++ b/packages/annotorious-openseadragon/src/Annotorious.ts
@@ -5,7 +5,7 @@ import {
   createBaseAnnotator, 
   createLifecycleObserver,
   createUndoStack, 
-  PointerSelectAction
+  SelectAction
 } from '@annotorious/core';
 import type { 
   Annotator, 
@@ -73,7 +73,7 @@ export const createOSDAnnotator = <E extends unknown = ImageAnnotation>(
   const opts = fillDefaults<ImageAnnotation, E>(options, {
     drawingEnabled: false,
     drawingMode: isTouch ? 'drag' : 'click',
-    pointerSelectAction: PointerSelectAction.EDIT,
+    selectAction: SelectAction.EDIT,
     theme: 'light'
   });
 
@@ -133,7 +133,7 @@ export const createOSDAnnotator = <E extends unknown = ImageAnnotation>(
     const blockEvent = drawingMode === 'click' && drawingEnabled;
 
     if (annotation && !blockEvent)
-      selection.clickSelect(annotation.id, originalEvent);
+      selection.eventSelect(annotation.id, originalEvent);
     else if (!selection.isEmpty())
       selection.clear();
   });

--- a/packages/annotorious-openseadragon/src/Annotorious.ts
+++ b/packages/annotorious-openseadragon/src/Annotorious.ts
@@ -133,7 +133,7 @@ export const createOSDAnnotator = <E extends unknown = ImageAnnotation>(
     const blockEvent = drawingMode === 'click' && drawingEnabled;
 
     if (annotation && !blockEvent)
-      selection.eventSelect(annotation.id, originalEvent);
+      selection.userSelect(annotation.id, originalEvent);
     else if (!selection.isEmpty())
       selection.clear();
   });

--- a/packages/annotorious-openseadragon/src/Annotorious.ts
+++ b/packages/annotorious-openseadragon/src/Annotorious.ts
@@ -5,7 +5,7 @@ import {
   createBaseAnnotator, 
   createLifecycleObserver,
   createUndoStack, 
-  SelectAction
+  UserSelectAction
 } from '@annotorious/core';
 import type { 
   Annotator, 
@@ -73,7 +73,7 @@ export const createOSDAnnotator = <E extends unknown = ImageAnnotation>(
   const opts = fillDefaults<ImageAnnotation, E>(options, {
     drawingEnabled: false,
     drawingMode: isTouch ? 'drag' : 'click',
-    selectAction: SelectAction.EDIT,
+    userSelectAction: UserSelectAction.EDIT,
     theme: 'light'
   });
 

--- a/packages/annotorious-openseadragon/src/index.ts
+++ b/packages/annotorious-openseadragon/src/index.ts
@@ -28,12 +28,14 @@ export type {
 import { 
   createBody as _createBody,
   defaultColorProvider as _defaultColorProvider,
-  PointerSelectAction as _PointerSelectAction
+  SelectAction as _SelectAction
 } from '@annotorious/core'; 
 
-export const defaultColorProvider = _defaultColorProvider;
-export const PointerSelectAction = _PointerSelectAction;
-export const createBody = _createBody;
+export {
+  _createBody as createBody,
+  _defaultColorProvider as defaultColorProvider,
+  _SelectAction as SelectAction
+}
 
 // Essential re-exports from @annotorious/annotorious 
 export type {

--- a/packages/annotorious-openseadragon/src/index.ts
+++ b/packages/annotorious-openseadragon/src/index.ts
@@ -28,13 +28,13 @@ export type {
 import { 
   createBody as _createBody,
   defaultColorProvider as _defaultColorProvider,
-  SelectAction as _SelectAction
+  UserSelectAction as _UserSelectAction
 } from '@annotorious/core'; 
 
 export {
   _createBody as createBody,
   _defaultColorProvider as defaultColorProvider,
-  _SelectAction as SelectAction
+  _UserSelectAction as UserSelectAction
 }
 
 // Essential re-exports from @annotorious/annotorious 

--- a/packages/annotorious-react/src/Annotorious.tsx
+++ b/packages/annotorious-react/src/Annotorious.tsx
@@ -64,14 +64,14 @@ export const Annotorious = forwardRef<Annotator, { children: ReactNode }>((props
       // from IDs to annotations automatically, for convenience
       let selectionStoreObserver: (event: StoreChangeEvent<Annotation>) => void;
 
-      const unsubscribeSelection = selection.subscribe(({ selected, pointerEvent }) => {
+      const unsubscribeSelection = selection.subscribe(({ selected, ...rest }) => {
         if (selectionStoreObserver) 
           store.unobserve(selectionStoreObserver);
 
         const resolved = (selected || [])
           .map(({ id, editable }) => ({ annotation: store.getAnnotation(id), editable }));
 
-        setSelection({ selected: resolved, pointerEvent });
+        setSelection({ selected: resolved, ...rest });
 
         selectionStoreObserver = event => {
           const { updated } = event.changes;

--- a/packages/annotorious-react/src/Annotorious.tsx
+++ b/packages/annotorious-react/src/Annotorious.tsx
@@ -1,13 +1,11 @@
 import { createContext, forwardRef, ReactNode} from 'react';
 import { useContext, useEffect, useImperativeHandle, useState } from 'react';
-import { Annotation, Annotator, Store, StoreChangeEvent, User } from '@annotorious/annotorious';
+import type { Annotation, Annotator, Store, StoreChangeEvent, User, Selection as CoreSelection } from '@annotorious/annotorious';
 import { useDebounce } from './useDebounce';
 
-interface Selection<T extends Annotation = Annotation> {
+interface Selection<T extends Annotation = Annotation> extends Omit<CoreSelection, 'selected'> {
 
   selected: { annotation: T, editable?: boolean }[];
-
-  pointerEvent?: PointerEvent;
 
 }
 

--- a/packages/annotorious-react/src/ImageAnnotator.tsx
+++ b/packages/annotorious-react/src/ImageAnnotator.tsx
@@ -11,7 +11,7 @@ export interface ImageAnnotatorProps<E extends unknown> extends AnnotoriousOpts<
 
   style?: DrawingStyle | ((annotation: ImageAnnotation) => DrawingStyle);
 
-  tool?: DrawingTool
+  tool?: DrawingTool;
 
 }
 

--- a/packages/annotorious-react/src/index.ts
+++ b/packages/annotorious-react/src/index.ts
@@ -44,14 +44,14 @@ import {
   createBody as _createBody,
   defaultColorProvider as _defaultColorProvider,
   Origin as _Origin,
-  SelectAction as _SelectAction
+  UserSelectAction as _UserSelectAction
 } from '@annotorious/core';
 
 export { _createAnonymousGuest as createAnonymousGuest };
 export { _createBody as createBody };
 export { _defaultColorProvider as defaultColorProvider };
 export { _Origin as Origin };
-export { _SelectAction as SelectAction };
+export { _UserSelectAction as UserSelectAction };
 
 // Essential re-exports from @annotorious/annotorious 
 export type {

--- a/packages/annotorious-react/src/index.ts
+++ b/packages/annotorious-react/src/index.ts
@@ -44,14 +44,14 @@ import {
   createBody as _createBody,
   defaultColorProvider as _defaultColorProvider,
   Origin as _Origin,
-  PointerSelectAction as _PointerSelectAction
+  SelectAction as _SelectAction
 } from '@annotorious/core';
 
 export { _createAnonymousGuest as createAnonymousGuest };
 export { _createBody as createBody };
 export { _defaultColorProvider as defaultColorProvider };
 export { _Origin as Origin };
-export { _PointerSelectAction as PointerSelectAction };
+export { _SelectAction as SelectAction };
 
 // Essential re-exports from @annotorious/annotorious 
 export type {

--- a/packages/annotorious-svelte/src/index.ts
+++ b/packages/annotorious-svelte/src/index.ts
@@ -37,14 +37,16 @@ import {
   createBody as _createBody,
   defaultColorProvider as _defaultColorProvider,
   Origin as _Origin,
-  PointerSelectAction as _PointerSelectAction
+  SelectAction as _SelectAction
 } from '@annotorious/core';
 
-export { _createAnonymousGuest as createAnonymousGuest };
-export { _createBody as createBody };
-export { _defaultColorProvider as defaultColorProvider };
-export { _Origin as Origin };
-export { _PointerSelectAction as PointerSelectAction };
+export {
+  _createAnonymousGuest as createAnonymousGuest,
+  _createBody as createBody,
+  _defaultColorProvider as defaultColorProvider,
+  _Origin as Origin,
+  _SelectAction as SelectAction
+}
 
 // Essential re-exports from @annotorious/annotorious 
 export type {

--- a/packages/annotorious-svelte/src/index.ts
+++ b/packages/annotorious-svelte/src/index.ts
@@ -37,7 +37,7 @@ import {
   createBody as _createBody,
   defaultColorProvider as _defaultColorProvider,
   Origin as _Origin,
-  SelectAction as _SelectAction
+  UserSelectAction as _UserSelectAction
 } from '@annotorious/core';
 
 export {
@@ -45,7 +45,7 @@ export {
   _createBody as createBody,
   _defaultColorProvider as defaultColorProvider,
   _Origin as Origin,
-  _SelectAction as SelectAction
+  _UserSelectAction as UserSelectAction
 }
 
 // Essential re-exports from @annotorious/annotorious 

--- a/packages/annotorious/src/Annotorious.ts
+++ b/packages/annotorious/src/Annotorious.ts
@@ -1,5 +1,5 @@
 import type { SvelteComponent } from 'svelte';
-import { SelectAction } from '@annotorious/core';
+import { UserSelectAction } from '@annotorious/core';
 import type { Annotator, DrawingStyleExpression, Filter, User } from '@annotorious/core';
 import { createAnonymousGuest, createBaseAnnotator, createLifecycleObserver, createUndoStack } from '@annotorious/core';
 import { registerEditor } from './annotation/editors';
@@ -48,7 +48,7 @@ export const createImageAnnotator = <E extends unknown = ImageAnnotation>(
   const opts = fillDefaults<ImageAnnotation, E>(options, {
     drawingEnabled: true,
     drawingMode: 'drag',
-    selectAction: SelectAction.EDIT,
+    userSelectAction: UserSelectAction.EDIT,
     theme: 'light'
   });
 

--- a/packages/annotorious/src/Annotorious.ts
+++ b/packages/annotorious/src/Annotorious.ts
@@ -1,5 +1,5 @@
 import type { SvelteComponent } from 'svelte';
-import { PointerSelectAction } from '@annotorious/core';
+import { SelectAction } from '@annotorious/core';
 import type { Annotator, DrawingStyleExpression, Filter, User } from '@annotorious/core';
 import { createAnonymousGuest, createBaseAnnotator, createLifecycleObserver, createUndoStack } from '@annotorious/core';
 import { registerEditor } from './annotation/editors';
@@ -41,13 +41,14 @@ export const createImageAnnotator = <E extends unknown = ImageAnnotation>(
   if (!image)
     throw 'Missing argument: image';
 
-  const img = (typeof image === 'string' ? 
-    document.getElementById(image) : image) as HTMLImageElement | HTMLCanvasElement;
+  const img = (
+    typeof image === 'string' ? document.getElementById(image) : image
+  ) as HTMLImageElement | HTMLCanvasElement;
 
   const opts = fillDefaults<ImageAnnotation, E>(options, {
     drawingEnabled: true,
     drawingMode: 'drag',
-    pointerSelectAction: PointerSelectAction.EDIT,
+    selectAction: SelectAction.EDIT,
     theme: 'light'
   });
 
@@ -93,7 +94,7 @@ export const createImageAnnotator = <E extends unknown = ImageAnnotation>(
   annotationLayer.$on('click', (evt: CustomEvent<SVGAnnotationLayerPointerEvent>) => {
     const { originalEvent, annotation } = evt.detail;
     if (annotation)
-      selection.clickSelect(annotation.id, originalEvent);
+      selection.eventSelect(annotation.id, originalEvent);
     else if (!selection.isEmpty())
       selection.clear();
   });

--- a/packages/annotorious/src/Annotorious.ts
+++ b/packages/annotorious/src/Annotorious.ts
@@ -94,7 +94,7 @@ export const createImageAnnotator = <E extends unknown = ImageAnnotation>(
   annotationLayer.$on('click', (evt: CustomEvent<SVGAnnotationLayerPointerEvent>) => {
     const { originalEvent, annotation } = evt.detail;
     if (annotation)
-      selection.eventSelect(annotation.id, originalEvent);
+      selection.userSelect(annotation.id, originalEvent);
     else if (!selection.isEmpty())
       selection.clear();
   });

--- a/packages/annotorious/src/AnnotoriousOpts.ts
+++ b/packages/annotorious/src/AnnotoriousOpts.ts
@@ -1,4 +1,4 @@
-import type { Annotation, DrawingStyle, DrawingStyleExpression, FormatAdapter, PointerSelectAction } from '@annotorious/core';
+import type { Annotation, DrawingStyle, DrawingStyleExpression, FormatAdapter, SelectAction } from '@annotorious/core';
 import type { ImageAnnotation } from './model';
 
 export interface AnnotoriousOpts<I extends Annotation = ImageAnnotation, E extends unknown = ImageAnnotation> {
@@ -13,7 +13,7 @@ export interface AnnotoriousOpts<I extends Annotation = ImageAnnotation, E exten
   // 'drag': starts drawing on drag, single click always selects
   drawingMode?: DrawingMode;
 
-  pointerSelectAction?: PointerSelectAction | ((a: I) => PointerSelectAction);
+  selectAction?: SelectAction | ((a: I) => SelectAction);
 
   style?: DrawingStyleExpression<ImageAnnotation>;
 
@@ -28,17 +28,13 @@ export type Theme = 'dark' | 'light' | 'auto';
 export const fillDefaults = <I extends ImageAnnotation = ImageAnnotation, E extends unknown = ImageAnnotation> (
   opts: AnnotoriousOpts<I, E>,
   defaults: AnnotoriousOpts<I, E>
-): AnnotoriousOpts<I, E> => {
-
-  return {
-    ...opts,
-    drawingEnabled: opts.drawingEnabled === undefined ? defaults.drawingEnabled : opts.drawingEnabled,
-    drawingMode: opts.drawingMode || defaults.drawingMode,
-    pointerSelectAction: opts.pointerSelectAction || defaults.pointerSelectAction,
-    theme: opts.theme || defaults.theme
-  };
-
-};
+): AnnotoriousOpts<I, E> => ({
+  ...opts,
+  drawingEnabled: opts.drawingEnabled === undefined ? defaults.drawingEnabled : opts.drawingEnabled,
+  drawingMode: opts.drawingMode || defaults.drawingMode,
+  selectAction: opts.selectAction || defaults.selectAction,
+  theme: opts.theme || defaults.theme
+});
 
 
 

--- a/packages/annotorious/src/AnnotoriousOpts.ts
+++ b/packages/annotorious/src/AnnotoriousOpts.ts
@@ -1,4 +1,4 @@
-import type { Annotation, DrawingStyle, DrawingStyleExpression, FormatAdapter, SelectAction } from '@annotorious/core';
+import type { Annotation, DrawingStyle, DrawingStyleExpression, FormatAdapter, UserSelectAction } from '@annotorious/core';
 import type { ImageAnnotation } from './model';
 
 export interface AnnotoriousOpts<I extends Annotation = ImageAnnotation, E extends unknown = ImageAnnotation> {
@@ -13,7 +13,7 @@ export interface AnnotoriousOpts<I extends Annotation = ImageAnnotation, E exten
   // 'drag': starts drawing on drag, single click always selects
   drawingMode?: DrawingMode;
 
-  selectAction?: SelectAction | ((a: I) => SelectAction);
+  userSelectAction?: UserSelectAction | ((a: I) => UserSelectAction);
 
   style?: DrawingStyleExpression<ImageAnnotation>;
 
@@ -32,7 +32,7 @@ export const fillDefaults = <I extends ImageAnnotation = ImageAnnotation, E exte
   ...opts,
   drawingEnabled: opts.drawingEnabled === undefined ? defaults.drawingEnabled : opts.drawingEnabled,
   drawingMode: opts.drawingMode || defaults.drawingMode,
-  selectAction: opts.selectAction || defaults.selectAction,
+  userSelectAction: opts.userSelectAction || defaults.userSelectAction,
   theme: opts.theme || defaults.theme
 });
 

--- a/packages/annotorious/src/state/ImageAnnotatorState.ts
+++ b/packages/annotorious/src/state/ImageAnnotatorState.ts
@@ -37,7 +37,7 @@ export const createImageAnnotatorState = <E extends unknown>(
 
   const tree = createSpatialTree();
 
-  const selection = createSelectionState(store, opts.pointerSelectAction);
+  const selection = createSelectionState(store, opts.selectAction);
 
   const hover = createHoverState(store);
 
@@ -85,4 +85,3 @@ export const createSvelteImageAnnotatorState = <E extends unknown>(
   }
 
 }
-  

--- a/packages/annotorious/src/state/ImageAnnotatorState.ts
+++ b/packages/annotorious/src/state/ImageAnnotatorState.ts
@@ -37,7 +37,7 @@ export const createImageAnnotatorState = <E extends unknown>(
 
   const tree = createSpatialTree();
 
-  const selection = createSelectionState(store, opts.selectAction);
+  const selection = createSelectionState(store, opts.userSelectAction);
 
   const hover = createHoverState(store);
 

--- a/packages/annotorious/test/index.html
+++ b/packages/annotorious/test/index.html
@@ -36,7 +36,7 @@
       window.onload = function() {
         // Just a weird dummy select action that makes
         // Polygons editable, but rectangles read-only
-        const pointerSelectAction = a => {
+        const selectAction = a => {
           if (a.target.selector.type === 'RECTANGLE') {
             return 'NONE';
           } else {

--- a/packages/annotorious/test/index.html
+++ b/packages/annotorious/test/index.html
@@ -36,7 +36,7 @@
       window.onload = function() {
         // Just a weird dummy select action that makes
         // Polygons editable, but rectangles read-only
-        const selectAction = a => {
+        const userSelectAction = a => {
           if (a.target.selector.type === 'RECTANGLE') {
             return 'NONE';
           } else {


### PR DESCRIPTION
## Issue - https://github.com/annotorious/annotorious/issues/419

## Changes Made
1. Replaced the `pointerEvent` with the generic `event` that can be triggered either by the `Keyboard` or the `Pointer`.
2. Replaced `clickSelect` with `userSelect` to signify that the selection is triggered by the user-induced event, and not be tied to the "click" concept
3. Renamed `PointerSelectAction` -> `UserSelectAction`