### PR TITLE
Added reaction to the `userSelectAction` prop update

### DIFF
--- a/packages/annotorious-react/src/ImageAnnotator.tsx
+++ b/packages/annotorious-react/src/ImageAnnotator.tsx
@@ -43,6 +43,10 @@ export const ImageAnnotator = <E extends unknown>(props: ImageAnnotatorProps<E>)
   useEffect(() => {
     if (anno) anno.setStyle(props.style);
   }, [props.style]);
+
+  useEffect(() => {
+    if (anno) anno.setUserSelectAction(props.userSelectAction);
+  }, [props.userSelectAction]);
  
   return <>{cloneElement(child, { onLoad }  as Partial<HTMLImageElement>)}</>
 


### PR DESCRIPTION
## Issue

In the https://github.com/annotorious/annotorious/commit/1daff59d1bf7e07df3a27620f131a3def52e1d60 commit the new `setUserSelectAction` method was added to the annotator API. Unfortunately, the React wrapper doesn't use it and it won't update the action upon its change in the `props`