### PR TITLE
Added annotation-oriented convenience React hooks

### DIFF
--- a/packages/annotorious-core/src/model/Annotator.ts
+++ b/packages/annotorious-core/src/model/Annotator.ts
@@ -1,9 +1,17 @@
 import type { Annotation } from './Annotation';
 import type { User } from './User';
-import type { PresenceProvider } from '../presence/PresenceProvider';
-import { Origin, UserSelectAction, type HoverState, type SelectionState, type Store, type UndoStack, type ViewportState } from '../state';
-import type { LifecycleEvents } from '../lifecycle/LifecycleEvents';
-import { parseAll, type FormatAdapter } from './FormatAdapter';
+import type { PresenceProvider } from '../presence';
+import {
+  type HoverState,
+  Origin,
+  type SelectionState,
+  type Store,
+  type UndoStack,
+  type UserSelectActionExpression,
+  type ViewportState
+} from '../state';
+import type { LifecycleEvents } from '../lifecycle';
+import { type FormatAdapter, parseAll } from './FormatAdapter';
 import type { DrawingStyleExpression } from './DrawingStyle';
 import type { Filter } from './Filter';
 
@@ -52,7 +60,7 @@ export interface Annotator<I extends Annotation = Annotation, E extends unknown 
 
   setUser(user: User): void;
 
-  setUserSelectAction(action: UserSelectAction | ((a: I) => UserSelectAction)): void;
+  setUserSelectAction(action: UserSelectActionExpression<I>): void;
 
   setVisible(visible: boolean): void;
 
@@ -170,7 +178,7 @@ export const createBaseAnnotator = <I extends Annotation, E extends unknown>(
     }
   }
 
-  const setUserSelectAction = (action: UserSelectAction | ((a: I) => UserSelectAction)) => {
+  const setUserSelectAction = (action: UserSelectActionExpression<I>) => {
     selection.clear();
     selection.setUserSelectAction(action);
   }

--- a/packages/annotorious-core/src/state/Selection.ts
+++ b/packages/annotorious-core/src/state/Selection.ts
@@ -24,11 +24,13 @@ export enum UserSelectAction {
 
 }
 
+export type UserSelectActionExpression<T extends Annotation> = UserSelectAction | ((a: T) => UserSelectAction);
+
 const EMPTY: Selection = { selected: [] };
 
 export const createSelectionState = <T extends Annotation>(
   store: Store<T>,
-  userSelectAction: UserSelectAction | ((a: T) => UserSelectAction) = UserSelectAction.EDIT
+  userSelectAction: UserSelectActionExpression<T> = UserSelectAction.EDIT
 ) => {
   const { subscribe, set } = writable<Selection>(EMPTY);
 
@@ -106,7 +108,7 @@ export const createSelectionState = <T extends Annotation>(
       set({ selected: selected.filter(({ id }) => !ids.includes(id)) });
   }
 
-  const setUserSelectAction = (action: UserSelectAction | ((a: T) => UserSelectAction)) =>
+  const setUserSelectAction = (action: UserSelectActionExpression<T>) =>
     currentUserSelectAction = action;
 
   // Track store delete and update events
@@ -134,5 +136,5 @@ export const createSelectionState = <T extends Annotation>(
 
 export const onUserSelect = <T extends Annotation>(
   annotation: T,
-  action?: UserSelectAction | ((a: T) => UserSelectAction)
+  action?: UserSelectActionExpression<T>
 ): UserSelectAction => (typeof action === 'function') ? action(annotation) : (action || UserSelectAction.EDIT);

--- a/packages/annotorious-react/src/Annotorious.tsx
+++ b/packages/annotorious-react/src/Annotorious.tsx
@@ -1,4 +1,4 @@
-import { createContext, forwardRef, useContext, useEffect, useImperativeHandle, useState, type ReactNode } from 'react';
+import { createContext, forwardRef, type ReactNode, useContext, useEffect, useImperativeHandle, useState } from 'react';
 import type {
   Annotation,
   Annotator,
@@ -7,7 +7,12 @@ import type {
   StoreChangeEvent,
   User
 } from '@annotorious/annotorious';
-import type { StoreObserveOptions } from '@annotorious/core';
+import {
+  onUserSelect,
+  type StoreObserveOptions,
+  UserSelectAction,
+  type UserSelectActionExpression
+} from '@annotorious/core';
 
 import { useDebounce } from './useDebounce';
 
@@ -159,6 +164,11 @@ export const useAnnotation = <T extends Annotation>(id: string, options?: Omit<S
   }, []);
 
   return annotation;
+}
+
+export const useAnnotationSelectAction = <T extends Annotation>(id: string, action: UserSelectActionExpression<T>) => {
+  const annotation = useAnnotation(id);
+  return annotation ? onUserSelect(annotation, action) : undefined;
 }
 
 export const useSelection = <T extends Annotation>() => {

--- a/packages/annotorious-react/src/Annotorious.tsx
+++ b/packages/annotorious-react/src/Annotorious.tsx
@@ -1,4 +1,4 @@
-import { createContext, forwardRef, ReactNode, useContext, useEffect, useImperativeHandle, useState } from 'react';
+import { createContext, forwardRef, useContext, useEffect, useImperativeHandle, useState, type ReactNode } from 'react';
 import type {
   Annotation,
   Annotator,
@@ -7,7 +7,7 @@ import type {
   StoreChangeEvent,
   User
 } from '@annotorious/annotorious';
-import { StoreObserveOptions } from '@annotorious/core';
+import type { StoreObserveOptions } from '@annotorious/core';
 
 import { useDebounce } from './useDebounce';
 

--- a/packages/annotorious/src/AnnotoriousOpts.ts
+++ b/packages/annotorious/src/AnnotoriousOpts.ts
@@ -1,4 +1,4 @@
-import type { Annotation, DrawingStyle, DrawingStyleExpression, FormatAdapter, UserSelectAction } from '@annotorious/core';
+import type { Annotation, DrawingStyleExpression, FormatAdapter, UserSelectActionExpression } from '@annotorious/core';
 import type { ImageAnnotation } from './model';
 
 export interface AnnotoriousOpts<I extends Annotation = ImageAnnotation, E extends unknown = ImageAnnotation> {
@@ -13,7 +13,7 @@ export interface AnnotoriousOpts<I extends Annotation = ImageAnnotation, E exten
   // 'drag': starts drawing on drag, single click always selects
   drawingMode?: DrawingMode;
 
-  userSelectAction?: UserSelectAction | ((a: I) => UserSelectAction);
+  userSelectAction?: UserSelectActionExpression<I>;
 
   style?: DrawingStyleExpression<ImageAnnotation>;
 


### PR DESCRIPTION
## Issue
1. There was no library-provided React hook for tracking changes for individual annotation. You could use smth like:
```tsx
const store = useAnnotationStore();
const annotation = store?.getAnnotation(id);
```
But that captures only a single "snapshot" of the annotation when the `getAnnotation` runs. It won't react to the subsequent underlying updates.
2. There was no simple React-based way to track the selection action for individual annotation by the id.

## Changes Made
1. Added the `useAnnotation` hook that reads the `store` for the 1st time and subscribes to the store update made for that annotation. It's convenient for the consuming app's components that want to know the latest `target`/`body` values and react to them accordingly.
2. Added the `useAnnotationSelectAction`. It's convenient for the consumer components that want to update the look based on the `UserSelectAction` for the annotations that are not yet selected. For example - the side note component should become "inert" and disabled when the `UserSelectAction` is `NONE`.