### PR TITLE
Applying style based on props

### DIFF
--- a/packages/annotorious/src/annotation/utils/styling.ts
+++ b/packages/annotorious/src/annotation/utils/styling.ts
@@ -1,26 +1,26 @@
-import type { DrawingStyleExpression } from "@annotorious/core";
-import type { ImageAnnotation } from "../../model";
+import type { DrawingStyleExpression } from '@annotorious/core';
+import type { ImageAnnotation } from '../../model';
 
 export const computeStyle = (
   annotation: ImageAnnotation,
   style?: DrawingStyleExpression<ImageAnnotation>
 ) => {
-  const computed = typeof style === "function" ? style(annotation) : style;
+  const computed = typeof style === 'function' ? style(annotation) : style;
 
   if (computed) {
     const { fill, fillOpacity, stroke, strokeWidth, strokeOpacity } = computed;
 
-    let css = "";
+    let css = '';
 
     if (fill) {
       css += `fill:${fill};`;
-      css += `fill-opacity:${fillOpacity || "0.25"};`;
+      css += `fill-opacity:${fillOpacity || '0.25'};`;
     }
 
     if (stroke) {
       css += `stroke:${stroke};`;
-      css += `stroke-width:${strokeWidth || "1"};`;
-      css += `stroke-opacity:${strokeOpacity || "1"};`;
+      css += `stroke-width:${strokeWidth || '1'};`;
+      css += `stroke-opacity:${strokeOpacity || '1'};`;
     }
 
     return css;

--- a/packages/annotorious/src/annotation/utils/styling.ts
+++ b/packages/annotorious/src/annotation/utils/styling.ts
@@ -1,22 +1,28 @@
-import type { DrawingStyleExpression } from '@annotorious/core';
-import type { ImageAnnotation } from '../../model';
+import type { DrawingStyleExpression } from "@annotorious/core";
+import type { ImageAnnotation } from "../../model";
 
 export const computeStyle = (
-  annotation: ImageAnnotation, 
+  annotation: ImageAnnotation,
   style?: DrawingStyleExpression<ImageAnnotation>
 ) => {
-  const computed = typeof style === 'function' ? style(annotation) : style;
+  const computed = typeof style === "function" ? style(annotation) : style;
 
   if (computed) {
-    const { fill, fillOpacity } = computed;
+    const { fill, fillOpacity, stroke, strokeWidth, strokeOpacity } = computed;
 
-    let css = '';
-    
-    if (fill)
-      css += `fill:${fill};stroke:${fill};`;
-    
-    css += `fill-opacity:${fillOpacity || '0.25'};`;
+    let css = "";
+
+    if (fill) {
+      css += `fill:${fill};`;
+      css += `fill-opacity:${fillOpacity || "0.25"};`;
+    }
+
+    if (stroke) {
+      css += `stroke:${stroke};`;
+      css += `stroke-width:${strokeWidth || "1"};`;
+      css += `stroke-opacity:${strokeOpacity || "1"};`;
+    }
 
     return css;
   }
-}
+};


### PR DESCRIPTION
When you use the `style` prop on `ImageAnnotator`, the style isn't applied properly

Example of style:

```
{
      fill: "#FFFFFF",
      stroke: "#FF0000",
      strokeOpacity: 0.4,
 };
```

Before:
![image](https://github.com/user-attachments/assets/3a71286e-d5f7-45a3-9bc0-a1f75ae99be2)

After:
![image](https://github.com/user-attachments/assets/aa7eb82f-5798-4c27-98c8-10e26fbb0cd6)
