### PR TITLE
Added comparison before clearing the selection

### DIFF
--- a/packages/annotorious-core/src/state/Selection.ts
+++ b/packages/annotorious-core/src/state/Selection.ts
@@ -1,4 +1,6 @@
 import { writable } from 'svelte/store';
+import { dequal } from 'dequal/lite';
+
 import type { Annotation } from '../model';
 import type { Store } from './Store';
 
@@ -40,7 +42,11 @@ export const createSelectionState = <T extends Annotation>(
 
   subscribe(updated => currentSelection = updated);
 
-  const clear = () => set(EMPTY);
+  const clear = () => {
+    if (!dequal(currentSelection, EMPTY)) {
+      set(EMPTY);
+    }
+  };
 
   const isEmpty = () => currentSelection.selected?.length === 0;
 

--- a/packages/annotorious-core/src/state/StoreObserver.ts
+++ b/packages/annotorious-core/src/state/StoreObserver.ts
@@ -142,7 +142,7 @@ export const mergeChanges = <T extends Annotation>(changes: ChangeSet<T>, toMerg
   const updatedIds = new Set((toMerge.updated || []).map(({ oldValue }) => oldValue.id));
 
   // Updates that will be merged into create or previous update events
-  const mergeableUpdates = new Set((toMerge.updated || [])
+  const mergeableUpdates = new Set((toMerge.updated || [])
     .filter(({ oldValue }) => previouslyCreatedIds.has(oldValue.id) || previouslyUpdatedIds.has(oldValue.id))
     .map(({ oldValue }) => oldValue.id ));
 


### PR DESCRIPTION
## Context
When you store objects in the Svelte store and call the `set`, all the listeners will be notified about the update, even when the value hasn't changed ([source](https://arc.net/l/quote/sveijxhx)):
> The store then checks whether the new value differs from the previous before notifying all of its subscribers. However, when the store contains an array or object, it _skips the check_, as seen from [the comparing algorithm](https://github.com/sveltejs/svelte/blob/670f4580568fe8ea31097981ba2d59c33daf0725/src/runtime/internal/utils.ts)

## Issue
If you subsequently call the `selection.clear()`, it will notify the `selection.subscribe` callback each time. That causes React components that read from the `useSelection` hook re-render each time too.

## Changes Made
Added a simple comparison before clearing the selection state. So calling the `selection.clear()` will notify the listeners only once.