### PR TITLE
Added `isIdling` to the `Selection` state

### DIFF
--- a/packages/annotorious-core/src/state/Selection.ts
+++ b/packages/annotorious-core/src/state/Selection.ts
@@ -9,6 +9,8 @@ export interface Selection {
 
   event?: PointerEvent | KeyboardEvent;
 
+  isIdling?: boolean;
+
 }
 
 export type SelectionState<I extends Annotation, E extends unknown> = ReturnType<typeof createSelectionState<I, E>>;
@@ -49,8 +51,7 @@ export const createSelectionState = <I extends Annotation, E extends unknown>(
   const isEmpty = () => currentSelection.selected?.length === 0;
 
   const isSelected = (annotationOrId: I | string) => {
-    if (isEmpty())
-      return false;
+    if (isEmpty()) return false;
 
     const id = typeof annotationOrId === 'string' ? annotationOrId : annotationOrId.id;
     return currentSelection.selected.some(i => i.id === id);
@@ -87,7 +88,8 @@ export const createSelectionState = <I extends Annotation, E extends unknown>(
 
     set({
       selected: annotations.map(annotation => {
-        // If editable is not set, use default behavior
+
+        // If editable isn't set, use the default behavior
         const isEditable = editable === undefined
           ? onUserSelect(annotation, currentUserSelectAction, adapter) === UserSelectAction.EDIT
           : editable;
@@ -112,6 +114,12 @@ export const createSelectionState = <I extends Annotation, E extends unknown>(
       set({ selected: selected.filter(({ id }) => !ids.includes(id)) });
   }
 
+  const setIdling = (isIdling: boolean) => {
+    if (currentSelection.isIdling !== isIdling) {
+      set({ ...currentSelection, isIdling });
+    }
+  }
+
   const setUserSelectAction = (action: UserSelectActionExpression<E> | undefined) =>
     currentUserSelectAction = action;
 
@@ -130,13 +138,17 @@ export const createSelectionState = <I extends Annotation, E extends unknown>(
     get userSelectAction() {
       return currentUserSelectAction;
     },
-    clear,
+    get isIdling() {
+      return currentSelection ? currentSelection.isIdling : null;
+    },
     isEmpty,
     isSelected,
     setSelected,
+    setIdling,
     setUserSelectAction,
+    userSelect,
     subscribe,
-    userSelect
+    clear
   };
 
 }

--- a/packages/annotorious-core/src/state/Selection.ts
+++ b/packages/annotorious-core/src/state/Selection.ts
@@ -9,8 +9,6 @@ export interface Selection {
 
   event?: PointerEvent | KeyboardEvent;
 
-  [key: string]: any; // Allow for additional properties to be added by plugins
-
 }
 
 export type SelectionState<I extends Annotation, E extends unknown> = ReturnType<typeof createSelectionState<I, E>>;
@@ -21,7 +19,7 @@ export enum UserSelectAction {
 
   SELECT = 'SELECT',  // Just select, but don't make editable
 
-  NONE = 'NONE' // Click won't select - annotation is completely inert
+  NONE = 'NONE' // Click won't select - the annotation is completely inert
 
 }
 


### PR DESCRIPTION
## Issue
See - https://github.com/recogito/text-annotator-js/issues/172. When a user rapidly selects the text down - their touch can go over the floating popup element which causes the highlight to flicker.
To prevent that, we decided to make the custom popup work similarly to the native context menu. It will appear only once the selection idles. 

## Changes Made
To represent that state I added the `isIdling` property to the `Selection` state. The value will automatically become accessible via the `useSelection` hook and will be reactive due to the Svelte `writable` properties.

#### Caveat
The `isIdling` value will only be utilized by the `r6o/text-annotator-js` for now. It already has a use-case for there and a relatively clear way to manage it.