### PR TITLE
Removed the arbitrary key from the `Selection`

### DIFF
--- a/packages/annotorious-core/src/state/Selection.ts
+++ b/packages/annotorious-core/src/state/Selection.ts
@@ -9,8 +9,6 @@ export interface Selection {
 
   event?: PointerEvent | KeyboardEvent;
 
-  [key: string]: any; // Allow for additional properties to be added by plugins
-
 }
 
 export type SelectionState<I extends Annotation, E extends unknown> = ReturnType<typeof createSelectionState<I, E>>;
@@ -21,7 +19,7 @@ export enum UserSelectAction {
 
   SELECT = 'SELECT',  // Just select, but don't make editable
 
-  NONE = 'NONE' // Click won't select - annotation is completely inert
+  NONE = 'NONE' // Click won't select - the annotation is completely inert
 
 }
 
@@ -89,7 +87,8 @@ export const createSelectionState = <I extends Annotation, E extends unknown>(
 
     set({
       selected: annotations.map(annotation => {
-        // If editable is not set, use default behavior
+
+        // If editable isn't set, use the default behavior
         const isEditable = editable === undefined
           ? onUserSelect(annotation, currentUserSelectAction, adapter) === UserSelectAction.EDIT
           : editable;


### PR DESCRIPTION
## Issue
Initially, it got discovered [here](https://github.com/annotorious/annotorious/commit/d4f974744ac1537380ea47e3b32d8dc399ade45a#commitcomment-148705705):
> I think that with the `set` removal, we should also clear the `[key: string]: any;` from: https://github.com/annotorious/annotorious/blob/733184ad5b4f22817f570abeb4900211549e4554/packages/annotorious-core/src/state/Selection.ts#L6-L14
Because there's technically no way for the consumers to add/update undeclared props w/o having unrestricted access to the `writable`'s `set`.