### PR TITLE
Fix ImageAnnotationPopup return statement

### DIFF
--- a/packages/annotorious-react/src/ImageAnnotationPopup.tsx
+++ b/packages/annotorious-react/src/ImageAnnotationPopup.tsx
@@ -132,7 +132,7 @@ export const ImageAnnotationPopup = (props: ImageAnnotationPopupProps) => {
     anno.state.store.updateBody(current, updated);
   }
 
-  return isOpen && annotation && (
+  return isOpen && annotation ? (
     <div
       className="a9s-popup a9s-image-popup"
       ref={refs.setFloating}
@@ -151,6 +151,6 @@ export const ImageAnnotationPopup = (props: ImageAnnotationPopupProps) => {
         onUpdateBody
       })}
     </div>
-  )
+  ) : <></>
 
 }


### PR DESCRIPTION
Hi, 

Thank you for such a nice project.

While using V 3.0.12 in React and trying the ImageAnnotationPopup component, I kept running into this error whenever I de-selected an annotation that had a popup:
`
K(...): Nothing was returned from render. This usually means a return statement is missing. Or, to render nothing, return null.
`

I debugged this to the return statement I changed. A JSX Element can't have a return value of boolean (or false in this case).

I copied and pasted the modified code into a replicated component inside my project and tested it. It works and fixes the issue.

I like the new popup changes and would love to use them in my project. I don't want to downgrade to 3.0.11, so I'd appreciate it if this got published soon. Thank you again.