### PR TITLE
Added generics usage for the `Update<T>` type

### DIFF
--- a/packages/annotorious-core/src/state/StoreObserver.ts
+++ b/packages/annotorious-core/src/state/StoreObserver.ts
@@ -37,13 +37,13 @@ export interface Update<T extends Annotation> {
 
   newValue: T;
 
-  bodiesCreated?: AnnotationBody[];
+  bodiesCreated?: T['bodies'];
 
-  bodiesDeleted?: AnnotationBody[];
+  bodiesDeleted?: T['bodies'];
 
-  bodiesUpdated?: Array<{ oldBody: AnnotationBody, newBody: AnnotationBody }>;
+  bodiesUpdated?: Array<{ oldBody: T['bodies'][number], newBody: T['bodies'][number] }>;
 
-  targetUpdated?: { oldTarget: AnnotationTarget, newTarget: AnnotationTarget};
+  targetUpdated?: { oldTarget: T['target'], newTarget: T['target'] };
 
 }
 


### PR DESCRIPTION
## Issue
Currently, when you listen to the store updates, the `bodiesCreated`, `bodiesDeleted`, `bodiesUpdated`, and `targetUpdated` will always fall back to their abstract types. Instead, they can be typed out using the prop's reading from the pre-specified generic type.
That will help the intellisense on the consumer side to properly access the Image/Text-specific properties.