### PR TITLE
Added internal type forwarding to the `Filter`

### DIFF
--- a/packages/annotorious-core/src/model/Annotator.ts
+++ b/packages/annotorious-core/src/model/Annotator.ts
@@ -54,7 +54,7 @@ export interface Annotator<I extends Annotation = Annotation, E extends unknown 
 
   setAnnotations(annotations: Partial<E>[], replace?: boolean): void;
 
-  setFilter(filter: Filter | undefined): void;
+  setFilter(filter: Filter<I> | undefined): void;
 
   setPresenceProvider?(provider: PresenceProvider): void;
 


### PR DESCRIPTION
## Issue
When you try to call the `setFilter` with the non-A9S internal type, like the `TextAnnotation` - you'll get an error:
<img width="908" alt="image" src="https://github.com/user-attachments/assets/9ab31d45-608b-438a-bdbb-ffcad1f981db">

## Changes Made
Added already present internal type forwarding to the `Filter`