### PR TITLE
Default cusor styling if user selection is set to none

### DIFF
--- a/packages/annotorious/src/Annotorious.css
+++ b/packages/annotorious/src/Annotorious.css
@@ -27,6 +27,10 @@
   cursor: pointer;
 }
 
+.a9s-annotationlayer .a9s-annotation.a9s-none-select {
+  cursor: default;
+}
+
 .a9s-annotationlayer ellipse, 
 .a9s-annotationlayer polygon,
 .a9s-annotationlayer rect  {

--- a/packages/annotorious/src/annotation/SVGAnnotationLayer.svelte
+++ b/packages/annotorious/src/annotation/SVGAnnotationLayer.svelte
@@ -155,17 +155,20 @@
         {#key annotation.id}
           {#if (selector?.type === ShapeType.ELLIPSE)}
             <Ellipse 
-              annotation={annotation} 
+              annotation={annotation}
+              isNoneSelection={selection.userSelectAction === "NONE"}
               geom={selector?.geometry} 
               style={style} />
           {:else if (selector?.type === ShapeType.RECTANGLE)}
             <Rectangle 
-              annotation={annotation} 
+              annotation={annotation}
+              isNoneSelection={selection.userSelectAction === "NONE"}
               geom={selector.geometry} 
               style={style} />
           {:else if (selector?.type === ShapeType.POLYGON)}
             <Polygon 
-              annotation={annotation} 
+              annotation={annotation}
+              isNoneSelection={selection.userSelectAction === "NONE"}
               geom={selector.geometry} 
               style={style} />
           {/if}

--- a/packages/annotorious/src/annotation/shapes/Ellipse.svelte
+++ b/packages/annotorious/src/annotation/shapes/Ellipse.svelte
@@ -7,13 +7,15 @@
   export let annotation: ImageAnnotation;
   export let geom: Geometry;
   export let style: DrawingStyleExpression<ImageAnnotation> | undefined;
+  export let isNoneSelection: boolean = false;
 
   $: computedStyle = computeStyle(annotation, style);
 
   const { cx, cy, rx, ry } = geom as EllipseGeometry;
 </script>
 
-<g class="a9s-annotation" data-id={annotation.id}>
+<g class={"a9s-annotation " + (isNoneSelection ? "a9s-none-select":  "")}
+   data-id={annotation.id}>
   <ellipse
     class="a9s-outer"
     style={computedStyle ? 'display:none;' : undefined}

--- a/packages/annotorious/src/annotation/shapes/Polygon.svelte
+++ b/packages/annotorious/src/annotation/shapes/Polygon.svelte
@@ -7,13 +7,15 @@
   export let annotation: ImageAnnotation;
   export let geom: Geometry;
   export let style: DrawingStyleExpression<ImageAnnotation> | undefined;
+  export let isNoneSelection: boolean = false;
 
   $: computedStyle = computeStyle(annotation, style);
 
   const { points } = geom as PolygonGeometry;
 </script>
 
-<g class="a9s-annotation" data-id={annotation.id}>
+<g class={"a9s-annotation " + (isNoneSelection ? "a9s-none-select":  "")}
+   data-id={annotation.id}>
   <polygon 
     class="a9s-outer"
     style={computedStyle ? 'display:none;' : undefined}

--- a/packages/annotorious/src/annotation/shapes/Rectangle.svelte
+++ b/packages/annotorious/src/annotation/shapes/Rectangle.svelte
@@ -7,13 +7,14 @@
   export let annotation: ImageAnnotation;
   export let geom: Geometry;
   export let style: DrawingStyleExpression<ImageAnnotation> | undefined;
+  export let isNoneSelection: boolean = false;
 
   $: computedStyle = computeStyle(annotation, style);
 
   $: ({ x, y, w, h } = geom as RectangleGeometry);
 </script>
 
-<g class="a9s-annotation" data-id={annotation.id}>
+<g class={"a9s-annotation " + (isNoneSelection ? "a9s-none-select":  "")} data-id={annotation.id}>
   <rect
     class="a9s-outer"
     style={computedStyle ? 'display:none;' : undefined}


### PR DESCRIPTION
Hi, 

I ran into this while wanting to display the annotations to users who aren't allowed to edit them. I hope I did it right, lmk if I need to change anything. 