### PR TITLE
#493 Added selection state re-evaluation on `userSelectAction` change

### DIFF
--- a/packages/annotorious-core/src/state/Selection.ts
+++ b/packages/annotorious-core/src/state/Selection.ts
@@ -125,8 +125,10 @@ export const createSelectionState = <I extends Annotation, E extends unknown>(
       set({ selected: selected.filter(({ id }) => !ids.includes(id)) });
   }
 
-  const setUserSelectAction = (action: UserSelectActionExpression<E> | undefined) =>
+  const setUserSelectAction = (action: UserSelectActionExpression<E> | undefined) => {
     currentUserSelectAction = action;
+    setSelected(currentSelection.selected.map(({ id }) => id));
+  };
 
   // Track store delete and update events
   store.observe(


### PR DESCRIPTION
## Issue
See - https://github.com/annotorious/annotorious/issues/493

>  A user can create an "impossible" state where the `userSelectAction` is `SELECT` or `NONE`, but both the `selected` is present and the `editable` is `true`.** 

## Changes Made
Added selection state re-evaluation call after updating the  `currentUserSelectAction`. That way, the `editing` property on the selection will stay up-to-date. Also, the consumers subscribed to the selection state will receive the updated state properly.