### PR TITLE
SVG path parser

### DIFF
--- a/packages/annotorious/svelte.config.js
+++ b/packages/annotorious/svelte.config.js
@@ -1,0 +1,7 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+  // Consult https://svelte.dev/docs#compile-time-svelte-preprocess
+  // for more information about preprocessors
+  preprocess: vitePreprocess(),
+}

--- a/packages/annotorious/test/model/w3c/W3CImageFormatAdapter.test.ts
+++ b/packages/annotorious/test/model/w3c/W3CImageFormatAdapter.test.ts
@@ -11,10 +11,11 @@ describe('parseW3CImageAnnotation', () => {
     expect(parsed[0].error).toBe(undefined);
     expect(parsed[1].error).toBe(undefined);
 
-    const [polygon, ellipse, rectangle] = parsed;
+    const [polygon, ellipse, path, rectangle] = parsed;
 
     expect(polygon.parsed?.target.selector.type).toBe(ShapeType.POLYGON);
     expect(ellipse.parsed?.target.selector.type).toBe(ShapeType.ELLIPSE);
+    expect(path.parsed?.target.selector.type).toBe(ShapeType.POLYGON);
     expect(rectangle.parsed?.target.selector.type).toBe(ShapeType.RECTANGLE);
   });
 });

--- a/packages/annotorious/test/model/w3c/fixtures.ts
+++ b/packages/annotorious/test/model/w3c/fixtures.ts
@@ -30,6 +30,22 @@ export const annotations = [{
         '<svg><ellipse cx="60" cy="80" rx="10" ry="10" /></svg>'
     }
   }
+},{
+  '@context': 'http://www.w3.org/ns/anno.jsonld',
+  id: 'http://www.example.com/annotation/185fb0e5-a6e1-42c3-b97d-b7da3ad023b9',
+  type: 'Annotation',
+  body: {
+    type: 'TextualBody',
+    value: 'Another comment'
+  },
+  target: {
+    source: 'http://www.example.com/source/1',
+    selector: {
+      type: 'SvgSelector',
+      value:
+          '<svg><path d="M150 5 L75 200 L225 200 Z" /></svg>'
+    }
+  }
 }, {
   '@context': 'http://www.w3.org/ns/anno.jsonld',
   id: 'http://www.example.com/annotation/a263656a-3dfe-4720-aae4-7a5a49c2f53f',

--- a/packages/annotorious/vitest.config.js
+++ b/packages/annotorious/vitest.config.js
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vitest/config';
+import { svelte } from "@sveltejs/vite-plugin-svelte";
 
 export default defineConfig({
+  plugins: [
+      svelte()
+  ],
   test: {
     environment: 'jsdom',
     watch: false


### PR DESCRIPTION
This PR adds a SVG path parser to the W3C adapter. The parser supports single line paths only and outputs a polygon shape.