### PR TITLE
chore: Update @floating-ui/react to fix React 19 issues.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -738,18 +738,18 @@
       }
     },
     "node_modules/@floating-ui/react": {
-      "version": "0.26.28",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
-      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.3.tgz",
+      "integrity": "sha512-CLHnes3ixIFFKVQDdICjel8muhFLOBdQH7fgtHNPY8UbCNqbeKZ262G7K66lGQOUQWWnYocf7ZbUsLJgGfsLHg==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.2",
-        "@floating-ui/utils": "^0.2.8",
+        "@floating-ui/utils": "^0.2.9",
         "tabbable": "^6.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     },
     "node_modules/@floating-ui/react-dom": {
@@ -766,9 +766,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
-      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -4745,7 +4745,7 @@
         "@annotorious/annotorious": "3.0.20",
         "@annotorious/core": "3.0.20",
         "@annotorious/openseadragon": "3.0.20",
-        "@floating-ui/react": "^0.26.28",
+        "@floating-ui/react": "^0.27.3",
         "zustand": "^5.0.1"
       },
       "devDependencies": {

--- a/packages/annotorious-react/package.json
+++ b/packages/annotorious-react/package.json
@@ -48,7 +48,7 @@
     "@annotorious/annotorious": "3.0.20",
     "@annotorious/core": "3.0.20",
     "@annotorious/openseadragon": "3.0.20",
-    "@floating-ui/react": "^0.26.28",
+    "@floating-ui/react": "^0.27.3",
     "zustand": "^5.0.1"
   },
   "sideEffects": false


### PR DESCRIPTION
After upgrading to React 19 and Next 15 while incorporating Annotorious on another branch, we found the Annotorious branch would not work with the latest changes any more. This is due to some dependencies relying on the now-defunct internal `__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` property of React.

A little digging and experimentation later, it seems updating the `@floating-ui/react` will resolve this issue nicely (at least in our case).

This PR provides the necessary changes, a new release should unblock anyone having problems.

Related conversation: https://github.com/orgs/annotorious/discussions/501