### PR TITLE
Fix/osd viewer reload

### DIFF
--- a/packages/annotorious-react/src/openseadragon/OpenSeadragonViewer.tsx
+++ b/packages/annotorious-react/src/openseadragon/OpenSeadragonViewer.tsx
@@ -28,13 +28,14 @@ export const OpenSeadragonViewer = forwardRef<OpenSeadragon.Viewer, OpenSeadrago
         setViewer(v);
 
       return () => {
+        console.log('Destroying viewer', JSON.stringify(options));
         if (setViewer)
           setViewer(undefined);
 
         v.destroy();
       }
     }
-  }, [JSON.stringify(options)]);
+  }, [options]);
 
   useImperativeHandle(ref, () => viewer);
 

--- a/packages/annotorious-react/src/openseadragon/OpenSeadragonViewer.tsx
+++ b/packages/annotorious-react/src/openseadragon/OpenSeadragonViewer.tsx
@@ -28,7 +28,6 @@ export const OpenSeadragonViewer = forwardRef<OpenSeadragon.Viewer, OpenSeadrago
         setViewer(v);
 
       return () => {
-        console.log('Destroying viewer', JSON.stringify(options));
         if (setViewer)
           setViewer(undefined);
 


### PR DESCRIPTION
Fixes #508 

Tested OK with images and geotifFTileSource.

Note: Might break the viewer for people who who properly memoize their OpenSeadragon options object.