### PR TITLE
Add setDrawingEnabled to Annotator type definition

### DIFF
--- a/packages/annotorious-core/src/model/Annotator.ts
+++ b/packages/annotorious-core/src/model/Annotator.ts
@@ -54,6 +54,8 @@ export interface Annotator<I extends Annotation = Annotation, E extends unknown 
 
   setAnnotations(annotations: Partial<E>[], replace?: boolean): void;
 
+  setDrawingEnabled(enabled: boolean): void;
+
   setFilter(filter: Filter<I> | undefined): void;
 
   setPresenceProvider?(provider: PresenceProvider): void;


### PR DESCRIPTION
The Annotator type definition is missing the setDrawingEnabled property