### PR TITLE
Added more rect edge controls. Proper cursors. Full edge to resize.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ A JavaScript image annotation library. Add drawing, commenting and labeling func
 in Web pages with just a few lines of code. Weighs less than 300kB. See the [project website](https://annotorious.github.io/)
 for details and live demos.
 
+
+## New Features in v2.7.14
+
+*   **Edge Dragging for Rectangles:**  Rectangular annotations can now be resized by dragging directly on their edges, providing a more intuitive resizing experience.
+*   **Automatic Cursor Updates:** The appropriate resize cursors (e.g., `ew-resize`, `ns-resize`, `nwse-resize`, `nesw-resize`) are automatically displayed when hovering over the edges or handles of a rectangle, giving a clear visual indication of available resizing actions.
+
 <img width="620" src="https://raw.githubusercontent.com/recogito/annotorious/master/screenshot.jpg" />
 
 ## Installing

--- a/public/index.html
+++ b/public/index.html
@@ -60,7 +60,6 @@
           image: 'hallstatt',
           locale: 'auto',
           drawOnSingleClick: true,
-          enableEdgeControls: true,
           widgets: [
             { widget: 'COMMENT' },
             { widget: 'TAG', vocabulary: [ 'Animal', 'Building', 'Waterbody'] }

--- a/src/tools/rectangle/EditableRect.js
+++ b/src/tools/rectangle/EditableRect.js
@@ -24,7 +24,7 @@ export default class EditableRect extends EditableShape {
 
   constructor(annotation, g, config, env) {
     super(annotation, g, config, env);
-
+    
     this.svg.addEventListener('mousemove', this.onMouseMove);
     this.svg.addEventListener('mouseup', this.onMouseUp);
 
@@ -61,10 +61,10 @@ export default class EditableRect extends EditableShape {
 
     this.elementGroup.appendChild(this.rectangle);
 
-    // Add edge rectangles for resizing
-    this.edges = this.createEdges(x, y, w, h);
+    // Add edge padding for resizing
+    this.edgePadding = this.createEdgePadding(x, y, w, h);
 
-    this.edges.forEach(edge => {
+    this.edgePadding.forEach(edge => {
       this.elementGroup.appendChild(edge);
       edge.addEventListener('mousedown', this.onGrab(edge, EDGE));
     });
@@ -123,73 +123,86 @@ export default class EditableRect extends EditableShape {
   }
 
   calculateEdgePadding = () => {
-    const basePadding = this.config.edgePadding ?? DEFAULT_EDGE_PADDING;
+    // const basePadding = this.config.edgePadding ?? DEFAULT_EDGE_PADDING;
 
-    let scaleFactor;
-    if (this.scale < 0.5) {
-      // When zoomed in deeply, we increase the padding slightly to make resizing easier.
-      scaleFactor = this.scale * 2;
-    } else {
-      scaleFactor = this.scale;
-    }
+    // let scaleFactor;
+    // if (this.scale < 0.5) {
+    //   // When zoomed in deeply, we increase the padding slightly to make resizing easier.
+    //   scaleFactor = this.scale * 2;
+    // } else {
+    //   scaleFactor = this.scale;
+    // }
 
-    const edgeResizePadding = basePadding * scaleFactor;
-    return Math.max(edgeResizePadding, 1);
+    // const edgeResizePadding = basePadding * scaleFactor;
+    // return Math.max(edgeResizePadding, 1);
+    return 3;
   }
 
   calculateHandlePadding = () => {
-    const basePadding = this.config.handlePadding ?? DEFAULT_HANDLE_PADDING;
+    // const basePadding = this.config.handlePadding ?? DEFAULT_HANDLE_PADDING;
 
-    let scaleFactor;
-    if (this.scale < 0.5) {
-      // When zoomed in deeply, we increase the padding slightly to make resizing easier
-      scaleFactor = this.scale * 2;
-    } else {
-      scaleFactor = this.scale / 2;
-    }
+    // let scaleFactor;
+    // if (this.scale < 0.5) {
+    //   // When zoomed in deeply, we increase the padding slightly to make resizing easier
+    //   scaleFactor = this.scale * 2;
+    // } else {
+    //   scaleFactor = this.scale / 2;
+    // }
 
-    const scaledPadSize = basePadding * scaleFactor;
-    return Math.max(scaledPadSize, 1);
+    // const scaledPadSize = basePadding * scaleFactor;
+    // return Math.max(scaledPadSize, 1);
+    return 5;
   }
 
-  createEdges(x, y, w, h) {
+  createEdgePadding(x, y, w, h) {
     const edgeResizePadding = this.calculateEdgePadding();
 
     return [
-      // Edges are drawn from top to bottom and left to right
-      this.createEdge(
-        x,
-        y - edgeResizePadding,
-        w,
-        2 * edgeResizePadding,
-        'ns-resize',
-        'top'
-      ),
-      this.createEdge(
-        x + w - edgeResizePadding,
-        y,
-        2 * edgeResizePadding,
-        h,
-        'ew-resize',
-        'right'
-      ),
-      this.createEdge(
-        x,
-        y + h - edgeResizePadding,
-        w,
-        2 * edgeResizePadding,
-        'ns-resize',
-        'bottom'
-      ),
-      this.createEdge(
-        x - edgeResizePadding,
-        y,
-        2 * edgeResizePadding,
-        h,
-        'ew-resize',
-        'left'
-      )
+      // top edge
+      this.createLine(x, y, x + w, y, 'ns-resize', 'top'),
+      // right edge
+      this.createLine(x + w, y, x + w, y + h, 'ew-resize', 'right'),
+      // bottom edge
+      this.createLine(x, y + h, x + w, y + h, 'ns-resize', 'bottom'),
+      // left edge
+      this.createLine(x, y, x, y + h, 'ew-resize', 'left')
     ];
+
+    // return [
+    //   // Edges are drawn from top to bottom and left to right
+    //   this.createEdge(
+    //     x,
+    //     y - edgeResizePadding,
+    //     w,
+    //     2 * edgeResizePadding,
+    //     'ns-resize',
+    //     'top'
+    //   ),
+    //   this.createEdge(
+    //     x + w - edgeResizePadding,
+    //     y,
+    //     2 * edgeResizePadding,
+    //     h,
+    //     'ew-resize',
+    //     'right'
+    //   ),
+    //   this.createEdge(
+    //     x,
+    //     y + h - edgeResizePadding,
+    //     w,
+    //     2 * edgeResizePadding,
+    //     'ns-resize',
+    //     'bottom'
+    //   ),
+    //   this.createEdge(
+    //     x - edgeResizePadding,
+    //     y,
+    //     2 * edgeResizePadding,
+    //     h,
+    //     'ew-resize',
+    //     'left'
+    //   )
+    // ];
   }
 
   createEdge(x, y, width, height, cursor, position) {
@@ -199,9 +212,22 @@ export default class EditableRect extends EditableShape {
     edge.setAttribute('width', width);
     edge.setAttribute('height', height);
     edge.setAttribute('class', `a9s-edge ${position}`);
-    edge.style.fill = 'transparent';
+    edge.style.fill = 'blue';
     edge.style.cursor = cursor;
     return edge;
+  }
+
+  createLine(x1, y1, x2, y2, cursor, position) {
+    const edgePadding = document.createElementNS(SVG_NAMESPACE, 'line');
+    edgePadding.setAttribute('x1', x1);
+    edgePadding.setAttribute('y1', y1);
+    edgePadding.setAttribute('x2', x2);
+    edgePadding.setAttribute('y2', y2);
+    edgePadding.setAttribute('class', `a9s-edge-pad ${position}`);
+    edgePadding.style.cursor = cursor;
+    edgePadding.style.stroke = 'blue';
+    edgePadding.setAttribute('stroke-width', 5)
+    return edgePadding;
   }
 
   createHandlePads(x, y, w, h) {
@@ -222,7 +248,7 @@ export default class EditableRect extends EditableShape {
     handlePad.setAttribute('cy', y);
     handlePad.setAttribute('r', radius);
     handlePad.setAttribute('class', 'a9s-handle-pad');
-    handlePad.style.fill = 'transparent';
+    handlePad.style.fill = 'red';
     handlePad.style.cursor = cursor;
     return handlePad;
   }
@@ -233,7 +259,7 @@ export default class EditableRect extends EditableShape {
   updateEdgePositions() {
     const edgeResizePadding = this.calculateEdgePadding();
     const { x, y, w, h } = getRectSize(this.rectangle);
-    const [top, right, bottom, left] = this.edges;
+    const [top, right, bottom, left] = this.edgePadding;
 
     top.setAttribute('x', x);
     top.setAttribute('y', y - edgeResizePadding);
@@ -256,10 +282,36 @@ export default class EditableRect extends EditableShape {
     left.setAttribute('height', h);
   }
 
+  updateEdgePadPositions() {
+    const { x, y, w, h } = getRectSize(this.rectangle);
+    const [top, right, bottom, left] = this.edgePadding;
+  
+    top.setAttribute('x1', x);
+    top.setAttribute('y1', y);
+    top.setAttribute('x2', x + w);
+    top.setAttribute('y2', y);
+  
+    right.setAttribute('x1', x + w);
+    right.setAttribute('y1', y);
+    right.setAttribute('x2', x + w);
+    right.setAttribute('y2', y + h);
+  
+    bottom.setAttribute('x1', x);
+    bottom.setAttribute('y1', y + h);
+    bottom.setAttribute('x2', x + w);
+    bottom.setAttribute('y2', y + h);
+  
+    left.setAttribute('x1', x);
+    left.setAttribute('y1', y);
+    left.setAttribute('x2', x);
+    left.setAttribute('y2', y + h);
+  }
+  
+
   updateHandlePadPositions = () => {
     const { x, y, w, h } = getRectSize(this.rectangle);
     const scaledPadSize = this.calculateHandlePadding();
-    const radius = scaledPadSize / 2;
+    const radius = scaledPadSize;
     const [topLeft, topRight, bottomRight, bottomLeft] = this.handlePads;
     topLeft.setAttribute('cx', x);
     topLeft.setAttribute('cy', y);
@@ -290,7 +342,7 @@ export default class EditableRect extends EditableShape {
     this.setHandleXY(bottomright, x + w, y + h);
     this.setHandleXY(bottomleft, x, y + h);
 
-    this.updateEdgePositions();
+    this.updateEdgePadPositions();
     this.updateHandlePadPositions();
   }
 

--- a/src/tools/rectangle/EditableRect.js
+++ b/src/tools/rectangle/EditableRect.js
@@ -30,25 +30,31 @@ export default class EditableRect extends EditableShape {
 
     const { x, y, w, h } = parseRectFragment(annotation, env.image);
 
-    // SVG markup for this class looks like this:
-    //
-    // <g>
-    //   <path class="a9s-selection-mask"... />
-    //   <g> <-- return this node as .element
-    //     <g>
-    //       <rect class="a9s-outer" ... />
-    //       <rect class="a9s-inner" ... />
-    //     </g>
-    //     <line class="a9s-edge-pad" ... /> (x4)
-    //     <g class="a9s-handle"> 
-    //       <g>
-    //         <circle class="a9s-handle-outer" ... />
-    //         <circle class="a9s-handle-inner" ... />
-    //       </g>
-    //     </g> (x4)
-    //     <circle class="a9s-handle-pad" ... /> (x4)
-    //   </g>
-    // </g>
+// SVG markup for this class looks like this:
+//
+// <g>
+//   <path class="a9s-selection-mask"... />
+//   <g> <-- return this node as .element
+//     <g>
+//       <rect class="a9s-outer" ... />
+//       <rect class="a9s-inner" ... />
+//     </g>
+//     <line class="a9s-edge-pad top" ... />
+//     <line class="a9s-edge-pad right" ... />
+//     <line class="a9s-edge-pad bottom" ... />
+//     <line class="a9s-edge-pad left" ... />
+//     <g class="a9s-handle"> 
+//       <g>
+//         <circle class="a9s-handle-outer" ... />
+//         <circle class="a9s-handle-inner" ... />
+//       </g>
+//     </g> (x4)
+//     <circle class="a9s-handle-pad top-left" ... />
+//     <circle class="a9s-handle-pad top-right" ... />
+//     <circle class="a9s-handle-pad bottom-right" ... />
+//     <circle class="a9s-handle-pad bottom-left" ... />
+//   </g>
+// </g>
 
 
     // 'g' for the editable rect compound shape
@@ -159,21 +165,21 @@ export default class EditableRect extends EditableShape {
 
   createHandlePads(x, y, w, h) {
     const radius = DEFAULT_HANDLE_PADDING;
-
+  
     return [
-      this.createHandlePad(x, y, radius, 'nwse-resize'), // top left
-      this.createHandlePad(x + w, y, radius, 'nesw-resize'), // top right
-      this.createHandlePad(x + w, y + h, radius, 'nwse-resize'), // bottom right
-      this.createHandlePad(x, y + h, radius, 'nesw-resize') // bottom left
+      this.createCircle(x, y, radius, 'nwse-resize', 'top-left'), // top left
+      this.createCircle(x + w, y, radius, 'nesw-resize', 'top-right'), // top right
+      this.createCircle(x + w, y + h, radius, 'nwse-resize', 'bottom-right'), // bottom right
+      this.createCircle(x, y + h, radius, 'nesw-resize', 'bottom-left') // bottom left
     ];
   }
 
-  createHandlePad(x, y, radius, cursor) {
+  createCircle(x, y, radius, cursor, position) {
     const handlePad = document.createElementNS(SVG_NAMESPACE, 'circle');
     handlePad.setAttribute('cx', x);
     handlePad.setAttribute('cy', y);
     handlePad.setAttribute('r', radius);
-    handlePad.setAttribute('class', 'a9s-handle-pad');
+    handlePad.setAttribute('class', `a9s-handle-pad ${position}`);
     handlePad.style.fill = 'transparent';
     handlePad.style.cursor = cursor;
     return handlePad;

--- a/src/tools/rectangle/EditableRect.js
+++ b/src/tools/rectangle/EditableRect.js
@@ -14,8 +14,8 @@ import {
 const HANDLE = 'handle';
 const EDGE = 'edge';
 
-const DEFAULT_EDGE_PADDING = 3;
-const DEFAULT_HANDLE_PADDING = 4;
+const DEFAULT_EDGE_PADDING = 5;
+const DEFAULT_HANDLE_PADDING = 7;
 
 /**
  * An editable rectangle shape.
@@ -302,8 +302,6 @@ export default class EditableRect extends EditableShape {
 
   onGrab = (grabbedElem, type) => evt => {
     if (evt.button !== 0) return;  // left click
-
-    evt.stopPropagation();
 
     this.grabbedElem = grabbedElem;
     this.grabbedType = type;

--- a/src/tools/rectangle/EditableRect.js
+++ b/src/tools/rectangle/EditableRect.js
@@ -14,8 +14,8 @@ import {
 const HANDLE = 'handle';
 const EDGE = 'edge';
 
-const DEFAULT_EDGE_PADDING = 5;
-const DEFAULT_HANDLE_PADDING = 10;
+const DEFAULT_EDGE_PADDING = 3;
+const DEFAULT_HANDLE_PADDING = 4;
 
 /**
  * An editable rectangle shape.
@@ -24,7 +24,7 @@ export default class EditableRect extends EditableShape {
 
   constructor(annotation, g, config, env) {
     super(annotation, g, config, env);
-    
+
     this.svg.addEventListener('mousemove', this.onMouseMove);
     this.svg.addEventListener('mouseup', this.onMouseUp);
 
@@ -33,14 +33,23 @@ export default class EditableRect extends EditableShape {
     // SVG markup for this class looks like this:
     //
     // <g>
-    //   <path class="a9s-selection mask"... />
+    //   <path class="a9s-selection-mask"... />
     //   <g> <-- return this node as .element
-    //     <rect class="a9s-outer" ... />
-    //     <rect class="a9s-inner" ... />
-    //     <rect class="a9s-edge" ... /> (x4)
-    //     <g class="a9s-handle" ...> ... </g> (x4)
+    //     <g>
+    //       <rect class="a9s-outer" ... />
+    //       <rect class="a9s-inner" ... />
+    //     </g>
+    //     <line class="a9s-edge-pad" ... /> (x4)
+    //     <g class="a9s-handle"> 
+    //       <g>
+    //         <circle class="a9s-handle-outer" ... />
+    //         <circle class="a9s-handle-inner" ... />
+    //       </g>
+    //     </g> (x4)
+    //     <circle class="a9s-handle-pad" ... /> (x4)
     //   </g>
     // </g>
+
 
     // 'g' for the editable rect compound shape
     this.containerGroup = document.createElementNS(SVG_NAMESPACE, 'g');
@@ -122,41 +131,7 @@ export default class EditableRect extends EditableShape {
     this.svgRoot = this.svg.closest('svg');
   }
 
-  calculateEdgePadding = () => {
-    // const basePadding = this.config.edgePadding ?? DEFAULT_EDGE_PADDING;
-
-    // let scaleFactor;
-    // if (this.scale < 0.5) {
-    //   // When zoomed in deeply, we increase the padding slightly to make resizing easier.
-    //   scaleFactor = this.scale * 2;
-    // } else {
-    //   scaleFactor = this.scale;
-    // }
-
-    // const edgeResizePadding = basePadding * scaleFactor;
-    // return Math.max(edgeResizePadding, 1);
-    return 3;
-  }
-
-  calculateHandlePadding = () => {
-    // const basePadding = this.config.handlePadding ?? DEFAULT_HANDLE_PADDING;
-
-    // let scaleFactor;
-    // if (this.scale < 0.5) {
-    //   // When zoomed in deeply, we increase the padding slightly to make resizing easier
-    //   scaleFactor = this.scale * 2;
-    // } else {
-    //   scaleFactor = this.scale / 2;
-    // }
-
-    // const scaledPadSize = basePadding * scaleFactor;
-    // return Math.max(scaledPadSize, 1);
-    return 5;
-  }
-
   createEdgePadding(x, y, w, h) {
-    const edgeResizePadding = this.calculateEdgePadding();
-
     return [
       // top edge
       this.createLine(x, y, x + w, y, 'ns-resize', 'top'),
@@ -167,54 +142,6 @@ export default class EditableRect extends EditableShape {
       // left edge
       this.createLine(x, y, x, y + h, 'ew-resize', 'left')
     ];
-
-    // return [
-    //   // Edges are drawn from top to bottom and left to right
-    //   this.createEdge(
-    //     x,
-    //     y - edgeResizePadding,
-    //     w,
-    //     2 * edgeResizePadding,
-    //     'ns-resize',
-    //     'top'
-    //   ),
-    //   this.createEdge(
-    //     x + w - edgeResizePadding,
-    //     y,
-    //     2 * edgeResizePadding,
-    //     h,
-    //     'ew-resize',
-    //     'right'
-    //   ),
-    //   this.createEdge(
-    //     x,
-    //     y + h - edgeResizePadding,
-    //     w,
-    //     2 * edgeResizePadding,
-    //     'ns-resize',
-    //     'bottom'
-    //   ),
-    //   this.createEdge(
-    //     x - edgeResizePadding,
-    //     y,
-    //     2 * edgeResizePadding,
-    //     h,
-    //     'ew-resize',
-    //     'left'
-    //   )
-    // ];
-  }
-
-  createEdge(x, y, width, height, cursor, position) {
-    const edge = document.createElementNS(SVG_NAMESPACE, 'rect');
-    edge.setAttribute('x', x);
-    edge.setAttribute('y', y);
-    edge.setAttribute('width', width);
-    edge.setAttribute('height', height);
-    edge.setAttribute('class', `a9s-edge ${position}`);
-    edge.style.fill = 'blue';
-    edge.style.cursor = cursor;
-    return edge;
   }
 
   createLine(x1, y1, x2, y2, cursor, position) {
@@ -225,14 +152,13 @@ export default class EditableRect extends EditableShape {
     edgePadding.setAttribute('y2', y2);
     edgePadding.setAttribute('class', `a9s-edge-pad ${position}`);
     edgePadding.style.cursor = cursor;
-    edgePadding.style.stroke = 'blue';
-    edgePadding.setAttribute('stroke-width', 5)
+    edgePadding.style.stroke = 'transparent';
+    edgePadding.setAttribute('stroke-width', DEFAULT_EDGE_PADDING)
     return edgePadding;
   }
 
   createHandlePads(x, y, w, h) {
-    const scaledPadSize = this.calculateHandlePadding();
-    const radius = scaledPadSize;
+    const radius = DEFAULT_HANDLE_PADDING;
 
     return [
       this.createHandlePad(x, y, radius, 'nwse-resize'), // top left
@@ -248,39 +174,13 @@ export default class EditableRect extends EditableShape {
     handlePad.setAttribute('cy', y);
     handlePad.setAttribute('r', radius);
     handlePad.setAttribute('class', 'a9s-handle-pad');
-    handlePad.style.fill = 'red';
+    handlePad.style.fill = 'transparent';
     handlePad.style.cursor = cursor;
     return handlePad;
   }
 
   onScaleChanged = () =>
     this.handles.map(this.scaleHandle);
-
-  updateEdgePositions() {
-    const edgeResizePadding = this.calculateEdgePadding();
-    const { x, y, w, h } = getRectSize(this.rectangle);
-    const [top, right, bottom, left] = this.edgePadding;
-
-    top.setAttribute('x', x);
-    top.setAttribute('y', y - edgeResizePadding);
-    top.setAttribute('width', w);
-    top.setAttribute('height', 2 * edgeResizePadding);
-
-    right.setAttribute('x', x + w - edgeResizePadding);
-    right.setAttribute('y', y);
-    right.setAttribute('width', 2 * edgeResizePadding);
-    right.setAttribute('height', h);
-
-    bottom.setAttribute('x', x);
-    bottom.setAttribute('y', y + h - edgeResizePadding);
-    bottom.setAttribute('width', w);
-    bottom.setAttribute('height', 2 * edgeResizePadding);
-
-    left.setAttribute('x', x - edgeResizePadding);
-    left.setAttribute('y', y);
-    left.setAttribute('width', 2 * edgeResizePadding);
-    left.setAttribute('height', h);
-  }
 
   updateEdgePadPositions() {
     const { x, y, w, h } = getRectSize(this.rectangle);
@@ -310,7 +210,7 @@ export default class EditableRect extends EditableShape {
 
   updateHandlePadPositions = () => {
     const { x, y, w, h } = getRectSize(this.rectangle);
-    const scaledPadSize = this.calculateHandlePadding();
+    const scaledPadSize = DEFAULT_HANDLE_PADDING;
     const radius = scaledPadSize;
     const [topLeft, topRight, bottomRight, bottomLeft] = this.handlePads;
     topLeft.setAttribute('cx', x);


### PR DESCRIPTION
This PR has the following changes.
*   **Edge Dragging for Rectangles:**  Rectangular annotations can now be resized by dragging directly on their edges, providing a more intuitive resizing experience. The full edge can be used for resizing.
*   **Automatic Cursor Updates:** The appropriate resize cursors (e.g., `ew-resize`, `ns-resize`, `nwse-resize`, `nesw-resize`) are automatically displayed when hovering over the edges or handles of a rectangle, giving a clear visual indication of available resizing actions.