### PR TITLE
Added `isW3CAnnotation` type guard

### DIFF
--- a/packages/annotorious-core/src/model/W3CAnnotation.ts
+++ b/packages/annotorious-core/src/model/W3CAnnotation.ts
@@ -1,4 +1,4 @@
-import type { AnnotationBody } from './Annotation';
+import type { Annotation, AnnotationBody } from './Annotation';
 
 export interface W3CAnnotation {
 
@@ -131,5 +131,5 @@ export const serializeW3CBodies = (bodies: AnnotationBody[]): W3CAnnotationBody[
     return w3cBody;
   });
 
-export const isW3CAnnotation = (annotation: any): annotation is W3CAnnotation =>
-  annotation && annotation['@context'] === 'http://www.w3.org/ns/anno.jsonld' && 'creator' in annotation
+export const isW3CAnnotation = (annotation: Annotation | W3CAnnotation): annotation is W3CAnnotation =>
+  '@context' in annotation && 'creator' in annotation;

--- a/packages/annotorious-core/src/model/W3CAnnotation.ts
+++ b/packages/annotorious-core/src/model/W3CAnnotation.ts
@@ -130,3 +130,6 @@ export const serializeW3CBodies = (bodies: AnnotationBody[]): W3CAnnotationBody[
 
     return w3cBody;
   });
+
+export const isW3CAnnotation = (annotation: any): annotation is W3CAnnotation =>
+  annotation && annotation['@context'] === 'http://www.w3.org/ns/anno.jsonld' && 'creator' in annotation

--- a/packages/annotorious-core/src/model/W3CAnnotation.ts
+++ b/packages/annotorious-core/src/model/W3CAnnotation.ts
@@ -132,4 +132,4 @@ export const serializeW3CBodies = (bodies: AnnotationBody[]): W3CAnnotationBody[
   });
 
 export const isW3CAnnotation = (annotation: Annotation | W3CAnnotation): annotation is W3CAnnotation =>
-  '@context' in annotation && 'creator' in annotation;
+  '@context' in annotation && 'creator' in annotation && 'body' in annotation;


### PR DESCRIPTION
## Issue
There's a relatively common need to check whether an `annotation` I'm working on uses the W3C or the internal model. Unfortunately, using just the `'@context' in annotation` isn't enough in the runtime. As during the parsing, it gets carried over to the internal model.

![CleanShot 2025-06-13 at 16 56 11](https://github.com/user-attachments/assets/95fb07bc-ac9c-407d-87d8-a0b1c2490a82)

## Changes Made
I added a shared `isW3CAnnotation` to conveniently differentiate between the model in the runtime.