### PR TITLE
Don't re-create the OSD viewer when only tileSources change

### DIFF
--- a/packages/annotorious-react/src/openseadragon/OpenSeadragonViewer.tsx
+++ b/packages/annotorious-react/src/openseadragon/OpenSeadragonViewer.tsx
@@ -1,5 +1,6 @@
-import { forwardRef, useContext, useEffect, useImperativeHandle, useLayoutEffect, useRef } from 'react';
+import { forwardRef, useContext, useImperativeHandle, useLayoutEffect, useRef } from 'react';
 import OpenSeadragon from 'openseadragon';
+import { dequal } from 'dequal/lite';
 import { OpenSeadragonAnnotatorContext } from './OpenSeadragonAnnotator';
 
 export interface OpenSeadragonViewerProps {
@@ -10,17 +11,40 @@ export interface OpenSeadragonViewerProps {
 
 }
 
+/**
+ * If the only thing that's changed about the options are the tileSources, there's no 
+ * need to destroy and re-generate the viewer, which can introduce dangerous race
+ * conditions and break interop with plugins. Changing the tileSource is probably 90%
+ * of the use case!
+ */
+const onlyTileSourcesChanged = (prev: OpenSeadragon.Options | undefined, next: OpenSeadragon.Options): boolean => {
+    if (!prev) return false;
+
+    const { tileSources: prevTiles, ...prevRest } = prev;
+    const { tileSources: nextTiles, ...nextRest } = next;
+
+    const tileSourcesChanged = !dequal(prevTiles, nextTiles);
+    const otherOptionsChanged = !dequal(prevRest, nextRest);
+
+    return tileSourcesChanged && !otherOptionsChanged;
+  };
+
 export const OpenSeadragonViewer = forwardRef<OpenSeadragon.Viewer, OpenSeadragonViewerProps>((props: OpenSeadragonViewerProps, ref) => {
 
   const { className, options } = props;
 
   const element = useRef<HTMLDivElement>(null);
+  const viewerRef = useRef<OpenSeadragon.Viewer | undefined>(null);
+  const prevOptionsRef = useRef<OpenSeadragon.Options>(null);
 
   const { viewer, setViewer } = useContext(OpenSeadragonAnnotatorContext);
 
-  useLayoutEffect(() => {    
-    if (element.current) {
+  // Init and destroy the OSD viewer on mount/unmount
+  useLayoutEffect(() => {  
+    if (element.current && !viewerRef.current) {
       const v = OpenSeadragon({...options, element: element.current });
+      viewerRef.current = v;
+      prevOptionsRef.current = options;
 
       // Checking for setViewer is just a convenience so we can
       // use this component also without an OpenSeadragonAnnotator
@@ -32,6 +56,48 @@ export const OpenSeadragonViewer = forwardRef<OpenSeadragon.Viewer, OpenSeadrago
           setViewer(undefined);
 
         v.destroy();
+        viewerRef.current = undefined;
+      }
+    }
+  }, []);
+
+  useLayoutEffect(() => {    
+    const v = viewerRef.current;
+    const prev = prevOptionsRef.current;
+    if (!v || !prev) return; 
+
+    if (onlyTileSourcesChanged(prev, options)) {      
+      const tileSources: OpenSeadragon.Options['tileSources'][] = 
+        Array.isArray(options.tileSources) ? options.tileSources : [options.tileSources];
+      
+      v.world.removeAll();
+
+      tileSources.forEach((tileSource, index) => {
+        v.addTiledImage({
+          tileSource,
+          index,
+          success: () => {
+            if (index === 0) {
+              v.viewport.goHome();
+            }
+          }
+        });
+      });
+    } else if (!dequal(prev, options)) {
+      console.warn('Forced re-creation of OpenSeadragon viewer. Beware of race conditions!');
+      
+      if (setViewer)
+        setViewer(undefined);
+      
+      v.destroy();
+
+      if (element.current) {
+        const newViewer = OpenSeadragon({...options, element: element.current });
+        viewerRef.current = newViewer;
+        prevOptionsRef.current = options;
+
+        if (setViewer)
+          setViewer(newViewer);
       }
     }
   }, [options]);

--- a/packages/annotorious-react/src/openseadragon/OpenSeadragonViewer.tsx
+++ b/packages/annotorious-react/src/openseadragon/OpenSeadragonViewer.tsx
@@ -12,10 +12,10 @@ export interface OpenSeadragonViewerProps {
 }
 
 /**
- * If the only thing that's changed about the options are the tileSources, there's no 
- * need to destroy and re-generate the viewer, which can introduce dangerous race
- * conditions and break interop with plugins. Changing the tileSource is probably 90%
- * of the use case!
+ * If the only thing that changes about the options are the tileSources, 
+ * there's no need to destroy and re-create the viewer, which can introduce
+ * dangerous race conditions and break interop with plugins. (Changing 
+ * tileSources is probably the main use case by far.)
  */
 const onlyTileSourcesChanged = (prev: OpenSeadragon.Options | undefined, next: OpenSeadragon.Options): boolean => {
     if (!prev) return false;


### PR DESCRIPTION
## In this PR

This PR improves behavior for issue #580. When changing the `options` prop on the React `<OpenSeadragonViewer />` component, the underlying OpenSeadragon viewer is no longer destroyed and re-created unncessarily when the only change is the `tileSources`.

A tileSource change is probably the most common scenario for changing the `options`, and can be covered more gracefully with a non-destructive, programmatic change of the tileSources through the OSD API. This doesn't prevent the problem of race conditions altogether (i.e. `viewer` getting regenerated while plugins manipulate the contents of the `viewer.element`). But it should make problems much less frequent, app-specific and workarounds easier.