### PR TITLE
Remove Svelte Dependency from the Core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3646,6 +3646,21 @@
         "node": "^18 || >=20"
       }
     },
+    "node_modules/nanostores": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.0.1.tgz",
+      "integrity": "sha512-kNZ9xnoJYKg/AfxjrVL4SS0fKX++4awQReGqWnwTRHxeHGZ1FJFVgTqr/eMrNQdp0Tz7M7tG/TDaX8QfHDwVCw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.25",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.25.tgz",
@@ -5068,14 +5083,11 @@
         "dequal": "^2.0.3",
         "nanoevents": "^9.1.0",
         "nanoid": "^5.1.6",
+        "nanostores": "^1.0.1",
         "uuid": "^13.0.0"
       },
       "devDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^3.1.2",
-        "@tsconfig/svelte": "^5.0.5",
         "@types/deep-equal": "^1.0.4",
-        "svelte": "^4.2.20",
-        "svelte-preprocess": "^6.0.3",
         "typescript": "^5.9.3",
         "vite": "^5.4.20",
         "vite-plugin-dts": "^4.5.4",

--- a/packages/annotorious-core/package.json
+++ b/packages/annotorious-core/package.json
@@ -26,11 +26,7 @@
     "dist"
   ],
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^3.1.2",
-    "@tsconfig/svelte": "^5.0.5",
     "@types/deep-equal": "^1.0.4",
-    "svelte": "^4.2.20",
-    "svelte-preprocess": "^6.0.3",
     "typescript": "^5.9.3",
     "vite": "^5.4.20",
     "vite-plugin-dts": "^4.5.4",
@@ -40,6 +36,7 @@
     "dequal": "^2.0.3",
     "nanoevents": "^9.1.0",
     "nanoid": "^5.1.6",
+    "nanostores": "^1.0.1",
     "uuid": "^13.0.0"
   }
 }

--- a/packages/annotorious-core/src/lifecycle/Lifecycle.ts
+++ b/packages/annotorious-core/src/lifecycle/Lifecycle.ts
@@ -1,7 +1,7 @@
 import { dequal } from 'dequal/lite';
 import type { Annotation, AnnotatorState, FormatAdapter } from '../model';
 import { Origin } from '../state';
-import type { ChangeSet, SelectionState, UndoStack } from '../state';
+import type { ChangeSet, UndoStack } from '../state';
 import type { LifecycleEvents } from './LifecycleEvents';
 
 export type Lifecycle<I extends Annotation, E extends unknown> = 

--- a/packages/annotorious-core/src/model/DrawingStyle.ts
+++ b/packages/annotorious-core/src/model/DrawingStyle.ts
@@ -1,5 +1,5 @@
-import type { Annotation } from "./Annotation";
-import type { AnnotationState } from "./AnnotationState";
+import type { Annotation } from './Annotation';
+import type { AnnotationState } from './AnnotationState';
 
 type RGB = `rgb(${number}, ${number}, ${number})`;
 

--- a/packages/annotorious-core/src/state/Selection.ts
+++ b/packages/annotorious-core/src/state/Selection.ts
@@ -1,4 +1,4 @@
-import { writable } from 'svelte/store';
+import { atom } from 'nanostores';
 import { dequal } from 'dequal/lite';
 import type { Annotation, FormatAdapter } from '../model';
 import type { Store } from './Store';
@@ -32,28 +32,28 @@ export const createSelectionState = <I extends Annotation, E extends unknown>(
   defaultSelectionAction?: UserSelectActionExpression<E>,
   adapter?: FormatAdapter<I, E>
 ) => {
-  const { subscribe, set } = writable<Selection>(EMPTY);
+  // const { subscribe, set } = writable<Selection>(EMPTY);
+  const selection = atom<Selection>(EMPTY);
 
   let currentUserSelectAction = defaultSelectionAction;
 
-  let currentSelection: Selection = EMPTY;
+  // let currentSelection: Selection = EMPTY;
 
-  subscribe(updated => currentSelection = updated);
+  // selection.subscribe(updated => currentSelection = updated);
 
   const clear = () => {
-    if (!dequal(currentSelection, EMPTY)) {
-      set(EMPTY);
-    }
+    if (!dequal(selection.get(), EMPTY))
+      selection.set(EMPTY);
   };
 
-  const isEmpty = () => currentSelection.selected?.length === 0;
+  const isEmpty = () => selection.get().selected?.length === 0;
 
   const isSelected = (annotationOrId: I | string) => {
     if (isEmpty())
       return false;
 
     const id = typeof annotationOrId === 'string' ? annotationOrId : annotationOrId.id;
-    return currentSelection.selected.some(i => i.id === id);
+    return selection.get().selected.some(i => i.id === id);
   }
 
   const userSelect = (idOrIds: string | string[], event?: Selection['event']) => {
@@ -86,7 +86,7 @@ export const createSelectionState = <I extends Annotation, E extends unknown>(
         return sel;
     }, []);
 
-    set({ selected, event });
+    selection.set({ selected, event });
   }
 
   const setSelected = (idOrIds: string | string[], editable?: boolean) => {
@@ -97,7 +97,7 @@ export const createSelectionState = <I extends Annotation, E extends unknown>(
       .map(id => store.getAnnotation(id))
       .filter((a): a is I => Boolean(a));
 
-    set({
+    selection.set({
       selected: annotations.map(annotation => {
 
         // If editable isn't set, use the default behavior
@@ -117,17 +117,17 @@ export const createSelectionState = <I extends Annotation, E extends unknown>(
     if (isEmpty())
       return false;
 
-    const { selected } = currentSelection;
+    const { selected } = selection.get();
 
     // Checks which of the given annotations are actually in the selection
     const shouldRemove = selected.some(({ id }) => ids.includes(id));
     if (shouldRemove)
-      set({ selected: selected.filter(({ id }) => !ids.includes(id)) });
+      selection.set({ selected: selected.filter(({ id }) => !ids.includes(id)) });
   }
 
   const setUserSelectAction = (action: UserSelectActionExpression<E> | undefined) => {
     currentUserSelectAction = action;
-    setSelected(currentSelection.selected.map(({ id }) => id));
+    setSelected(selection.get().selected.map(({ id }) => id));
   };
 
   // Utility to evaluate what the select action will be for the given annotation
@@ -141,10 +141,12 @@ export const createSelectionState = <I extends Annotation, E extends unknown>(
 
   return {
     get event() {
-      return currentSelection ? currentSelection.event : null;
+      const current = selection.get();
+      return current ? current.event : null;
     },
     get selected() {
-      return currentSelection ? [...currentSelection.selected] : null;
+      const current = selection.get();
+      return current ? [...current.selected] : null;
     },
     get userSelectAction() {
       return currentUserSelectAction;
@@ -155,7 +157,7 @@ export const createSelectionState = <I extends Annotation, E extends unknown>(
     isSelected,
     setSelected,
     setUserSelectAction,
-    subscribe,
+    subscribe: selection.subscribe.bind(selection),
     userSelect
   };
 

--- a/packages/annotorious-core/src/state/Selection.ts
+++ b/packages/annotorious-core/src/state/Selection.ts
@@ -32,14 +32,9 @@ export const createSelectionState = <I extends Annotation, E extends unknown>(
   defaultSelectionAction?: UserSelectActionExpression<E>,
   adapter?: FormatAdapter<I, E>
 ) => {
-  // const { subscribe, set } = writable<Selection>(EMPTY);
   const selection = atom<Selection>(EMPTY);
 
   let currentUserSelectAction = defaultSelectionAction;
-
-  // let currentSelection: Selection = EMPTY;
-
-  // selection.subscribe(updated => currentSelection = updated);
 
   const clear = () => {
     if (!dequal(selection.get(), EMPTY))

--- a/packages/annotorious-core/src/state/StoreObserver.ts
+++ b/packages/annotorious-core/src/state/StoreObserver.ts
@@ -1,4 +1,4 @@
-import type { Annotation, AnnotationBody, AnnotationTarget } from '../model/Annotation';
+import type { Annotation } from '../model/Annotation';
 import { diffAnnotations } from '../utils';
 
 /** Interface for listening to changes in the annotation store **/

--- a/packages/annotorious-core/src/state/UndoStack.ts
+++ b/packages/annotorious-core/src/state/UndoStack.ts
@@ -1,8 +1,8 @@
 import { createNanoEvents, type Unsubscribe } from 'nanoevents';
 import type { Annotation } from '../model';
 import type { Store } from './Store';
-import { Origin } from './StoreObserver';
-import { mergeChanges, type ChangeSet, type StoreChangeEvent, type Update } from './StoreObserver';
+import { mergeChanges, Origin } from './StoreObserver';
+import type { ChangeSet, StoreChangeEvent, Update } from './StoreObserver';
 
 // Duration with fast successive changes get merged 
 // with the last event in the stack, rather than getting stacked

--- a/packages/annotorious-core/src/state/Viewport.ts
+++ b/packages/annotorious-core/src/state/Viewport.ts
@@ -1,14 +1,14 @@
-import { writable } from 'svelte/store';
+import { atom } from 'nanostores';
 
 export type ViewportState = ReturnType<typeof createViewportState>;
 
 export const createViewportState = () => {
 
-  const { subscribe, set } = writable<string[]>([]);
+  const inViewport = atom<string[]>([]);
 
   return { 
-    subscribe, 
-    set
+    subscribe: inViewport.subscribe.bind(inViewport), 
+    set: inViewport.set.bind(inViewport)
   };
 
 }

--- a/packages/annotorious-core/src/state/index.ts
+++ b/packages/annotorious-core/src/state/index.ts
@@ -2,6 +2,5 @@ export * from './Hover';
 export * from './Selection';
 export * from './Store';
 export * from './StoreObserver';
-export * from './SvelteStore';
 export * from './UndoStack';
 export * from './Viewport';

--- a/packages/annotorious-core/test/state/Hover.test.ts
+++ b/packages/annotorious-core/test/state/Hover.test.ts
@@ -36,7 +36,7 @@ describe('createHoverState', () => {
   it('should remove the hover when the annotation is deleted', () => {
     hoverState.set(testAnnotation.id);
 
-    let hover: string | undefined;
+    let hover: string | null;
 
     const mockObserver = vi.fn(id => hover = id);
     hoverState.subscribe(mockObserver);
@@ -44,7 +44,7 @@ describe('createHoverState', () => {
     store.deleteAnnotation(testAnnotation);
 
     expect(mockObserver).toHaveBeenCalled();
-    expect(hover).toBeUndefined();
+    expect(hover).toBeNull();
   });
 
 });

--- a/packages/annotorious-core/tsconfig.json
+++ b/packages/annotorious-core/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
     "checkJs": true,

--- a/packages/annotorious-core/vite.config.js
+++ b/packages/annotorious-core/vite.config.js
@@ -1,11 +1,8 @@
 import { defineConfig } from 'vite';
-import { svelte } from '@sveltejs/vite-plugin-svelte';
-import sveltePreprocess from 'svelte-preprocess';
 import dts from 'vite-plugin-dts';
 
 export default defineConfig({
   plugins: [
-    svelte({ preprocess: sveltePreprocess() }),
     dts({ 
       insertTypesEntry: true,
       include: ['./src/'],

--- a/packages/annotorious-svelte/src/index.ts
+++ b/packages/annotorious-svelte/src/index.ts
@@ -24,8 +24,6 @@ export type {
   Store,
   StoreChangeEvent,
   StoreObserver,
-  SvelteAnnotator,
-  SvelteAnnotatorState,
   User,
   W3CAnnotation,
   W3CAnnotationBody,
@@ -53,7 +51,9 @@ export type {
   PolygonGeometry,
   Rectangle,
   RectangleGeometry,
-  Shape
+  Shape,
+  SvelteAnnotator,
+  SvelteAnnotatorState
 } from '@annotorious/annotorious';
 
 export {   

--- a/packages/annotorious/src/state/ImageAnnotationStore.ts
+++ b/packages/annotorious/src/state/ImageAnnotationStore.ts
@@ -1,4 +1,5 @@
-import type { Annotation, Filter, Store, SvelteAnnotatorState, SvelteStore } from '@annotorious/core';
+import type { Annotation, Filter, Store } from '@annotorious/core';
+import type { SvelteAnnotatorState, SvelteStore } from './SvelteStore';
 
 export type ImageAnnotationStore<I extends Annotation> = Store<I> & {
 

--- a/packages/annotorious/src/state/ImageAnnotatorState.ts
+++ b/packages/annotorious/src/state/ImageAnnotatorState.ts
@@ -1,9 +1,9 @@
 import type { ImageAnnotation, ImageAnnotationTarget } from '../model';
 import type { AnnotoriousOpts } from '../AnnotoriousOpts';
 import { createSpatialTree } from './spatialTree';
+import { toSvelteStore } from './SvelteStore';
 import { 
   createViewportState,
-  toSvelteStore,
   type Annotation,
   type AnnotatorState, 
   type Filter, 

--- a/packages/annotorious/src/state/SvelteStore.ts
+++ b/packages/annotorious/src/state/SvelteStore.ts
@@ -1,6 +1,4 @@
-import type { Annotation, Annotator, AnnotatorState } from '../model';
-import type { Store } from './Store';
-import type { StoreChangeEvent } from './StoreObserver';
+import type { Annotation, Annotator, AnnotatorState, Store, StoreChangeEvent } from '@annotorious/core';
 
 type Subscriber<T extends Annotation> = (annotation: T[]) => void; 
 

--- a/packages/annotorious/src/state/index.ts
+++ b/packages/annotorious/src/state/index.ts
@@ -1,2 +1,3 @@
 export * from './ImageAnnotationStore';
 export * from './ImageAnnotatorState';
+export * from './SvelteStore';


### PR DESCRIPTION
Step one in the process of removing Svelte from Annotorious: This PR removes the any dependency on Svelte from `@annotorious/core`. The core only made use of the Svelte `writeable` store utility, which is now implemented using [nanostores](https://github.com/nanostores/nanostores).