### PR TITLE
fix: incorrect stroke widths with multiple OSD viewers

### DIFF
--- a/packages/annotorious-openseadragon/src/annotation/pixi/stageRenderer.ts
+++ b/packages/annotorious-openseadragon/src/annotation/pixi/stageRenderer.ts
@@ -297,8 +297,15 @@ export const createStage = (viewer: OpenSeadragon.Viewer, canvas: HTMLCanvasElem
   lastScale = getCurrentScale(viewer);
 
   const addAnnotation = (annotation: ImageAnnotation, state?: AnnotationState) => {
+    // Ensure lastScale reflects this viewer's current viewport scale.
+    // lastScale is module-scoped and shared across all createStage instances,
+    // so it may hold a stale value from a different viewer. drawShape reads
+    // lastScale to compute counter-scaled stroke widths, so we must sync it
+    // here before any shapes are drawn.
+    lastScale = getCurrentScale(viewer);
+
     // In case this annotation adds stroke > 1
-    fastRedraw = false; 
+    fastRedraw = false;
 
     // Robustness: make sure to delete any annotation with the same ID, because 
     // otherwise we'd replace the annotation in `annotationShapes` and leave 


### PR DESCRIPTION
## Summary

Fixes #596 — annotation stroke widths render incorrectly when multiple `OpenSeadragonAnnotator` instances share a page.

## Problem

`lastScale` and `fastRedraw` are declared at module scope in `stageRenderer.ts` (lines 31–34) and shared across every `createStage` instance. When viewer A's `redrawStage` writes its viewport scale to `lastScale`, a subsequent `addAnnotation` call on viewer B (e.g. triggered by hover) reads A's scale value. `drawShape` then computes `strokeWidth / lastScale` with the wrong denominator, producing visibly incorrect stroke widths.

## Fix

Sync `lastScale` to the current viewer at the top of `addAnnotation`, before any shapes are drawn:

```typescript
const addAnnotation = (annotation: ImageAnnotation, state?: AnnotationState) => {
    lastScale = getCurrentScale(viewer);
    fastRedraw = false;
    // ...
```

This is a minimal, targeted fix. A more thorough follow-up could move `lastScale` and `fastRedraw` into `createStage`'s closure to eliminate the shared mutable state entirely.

## Test plan

- [ ] Render two `OpenSeadragonAnnotator` instances side-by-side, both with annotations using `strokeWidth > 1`
- [ ] Zoom in/out on viewer A
- [ ] Hover over annotations on viewer B — stroke widths should remain correct
- [ ] Verify single-viewer usage is unaffected