### PR TITLE
Rectangle rotation

### DIFF
--- a/packages/annotorious-openseadragon/src/annotation/pixi/stageRenderer.ts
+++ b/packages/annotorious-openseadragon/src/annotation/pixi/stageRenderer.ts
@@ -98,8 +98,15 @@ const drawShape = <T extends Shape>(
 }
 
 const drawRectangle = drawShape((rectangle: Rectangle, g: PIXI.Graphics) => {
-  const { x, y, w, h } = rectangle.geometry;
-  g.drawRect(x, y, w, h);
+  const { x, y, w, h, rot } = rectangle.geometry;
+  if (rot === 0) {
+   g.drawRect(x, y, w, h);
+  } else {
+    g.position.set(x + w/2, y + h/2);
+    g.pivot.set(0, 0);
+    g.rotation = rot;
+    g.drawRect(-w/2, -h/2, w, h);
+  }
 });
 
 const drawEllipse = drawShape((ellipse: Ellipse, g: PIXI.Graphics) => {

--- a/packages/annotorious-openseadragon/src/annotation/pixi/stageRenderer.ts
+++ b/packages/annotorious-openseadragon/src/annotation/pixi/stageRenderer.ts
@@ -98,7 +98,7 @@ const drawShape = <T extends Shape>(
 }
 
 const drawRectangle = drawShape((rectangle: Rectangle, g: PIXI.Graphics) => {
-  const { x, y, w, h, rot } = rectangle.geometry;
+  const { x, y, w, h, rot = 0 } = rectangle.geometry;
   if (rot === 0) {
    g.drawRect(x, y, w, h);
   } else {

--- a/packages/annotorious-openseadragon/src/annotation/pixi/stageRenderer.ts
+++ b/packages/annotorious-openseadragon/src/annotation/pixi/stageRenderer.ts
@@ -103,7 +103,6 @@ const drawRectangle = drawShape((rectangle: Rectangle, g: PIXI.Graphics) => {
    g.drawRect(x, y, w, h);
   } else {
     g.position.set(x + w/2, y + h/2);
-    g.pivot.set(0, 0);
     g.rotation = rot;
     g.drawRect(-w/2, -h/2, w, h);
   }

--- a/packages/annotorious-openseadragon/test/annotations.core.json
+++ b/packages/annotorious-openseadragon/test/annotations.core.json
@@ -1,5 +1,32 @@
 [
   {
+    "id": "ca3beec3-d73e-4893-9871-acd4e30ef6f8",
+    "bodies": [],
+    "target": {
+      "annotation": "ca3beec3-d73e-4893-9871-acd4e30ef6f8",
+      "selector": {
+        "type": "RECTANGLE",
+        "geometry": {
+          "x": 776.6638044268843,
+          "y": 1325.5515644955299,
+          "w": 929.0114650907483,
+          "h": 787.6476692209455,
+          "bounds": {
+            "minX": 776.6638044268843,
+            "minY": 1325.5515644955299,
+            "maxX": 1705.6752695176326,
+            "maxY": 2113.1992337164756
+          }
+        }
+      },
+      "creator": {
+        "isGuest": true,
+        "id": "1HyYU8ipIejMn7BmaTo1"
+      },
+      "created": "2026-03-16T06:39:16.572Z"
+    }
+  },
+  {
     "id": "ec2dbf64-58fd-4b38-a096-d98243d78423",
     "bodies": [],
     "target": {

--- a/packages/annotorious-openseadragon/test/index.html
+++ b/packages/annotorious-openseadragon/test/index.html
@@ -83,8 +83,6 @@
           // userSelectAction: 'SELECT'
         });
 
-        anno.setDrawingTool('polygon');
-
         // fetch('annotations.w3c.json').then((response) => response.json())
         fetch('annotations.core.json').then((response) => response.json())
           .then(annotations =>

--- a/packages/annotorious-openseadragon/test/index.html
+++ b/packages/annotorious-openseadragon/test/index.html
@@ -62,8 +62,6 @@
         });
 
         const BASE_STYLE = function(a, state) {
-          console.log(state);
-
           const { hovered, selected } = state || {};
           return {
             fill: hovered ? 'rgba(180,0,60,0.7)' : 'rgba(180,0,60,0.5)',

--- a/packages/annotorious/src/Annotorious.css
+++ b/packages/annotorious/src/Annotorious.css
@@ -93,6 +93,7 @@
   fill: transparent;
   stroke: transparent;
   stroke-width: 6px;
+  vector-effect: non-scaling-stroke;
 }
 
 .a9s-shape-handle {

--- a/packages/annotorious/src/annotation/editors/rectangle/RectangleEditor.svelte
+++ b/packages/annotorious/src/annotation/editors/rectangle/RectangleEditor.svelte
@@ -2,12 +2,11 @@
   import { onMount } from 'svelte';
   import Handle from '../Handle.svelte';
   import { getMaskDimensions } from '../../utils';
-  import type { Rectangle, RectangleGeometry, Shape } from '../../../model';
+  import { boundsFromPoints, type Rectangle, type RectangleGeometry, type Shape } from '../../../model';
   import type { Transform } from '../../Transform';
   import { Editor } from '..';
   import {
     getRotatedCorners,
-    getBoundsFromRotatedRect,
     getRotationHandlePosition,
     transformDeltaToLocalCoords,
     angleFromPoints,
@@ -118,7 +117,7 @@
     }
 
     // Calculate new bounds
-    const bounds = getBoundsFromRotatedRect(x, y, w, h, rot);
+    const bounds = boundsFromPoints(rotatedCorners);
 
     return {
       ...rectangle,

--- a/packages/annotorious/src/annotation/editors/rectangle/RectangleEditor.svelte
+++ b/packages/annotorious/src/annotation/editors/rectangle/RectangleEditor.svelte
@@ -23,7 +23,7 @@
 
   let shiftPressed = false;
 
-  const ROTATION_HANDLE_OFFSET = 20 / viewportScale;
+  $: ROTATION_HANDLE_OFFSET = 20 / viewportScale;
 
   $: geom = shape.geometry;
   $: rotatedCorners = getRotatedCorners(geom.x, geom.y, geom.w, geom.h, geom.rot);

--- a/packages/annotorious/src/annotation/editors/rectangle/RectangleEditor.svelte
+++ b/packages/annotorious/src/annotation/editors/rectangle/RectangleEditor.svelte
@@ -1,9 +1,18 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import Handle from '../Handle.svelte';
   import { getMaskDimensions } from '../../utils';
-  import type { Rectangle, Shape } from '../../../model';
+  import type { Rectangle, RectangleGeometry, Shape } from '../../../model';
   import type { Transform } from '../../Transform';
   import { Editor } from '..';
+  import {
+    getRotatedCorners,
+    getBoundsFromRotatedRect,
+    getRotationHandlePosition,
+    transformDeltaToLocalCoords,
+    angleFromPoints,
+    snapAngle
+  } from './rotationUtils';
 
   /** Props */
   export let shape: Rectangle;
@@ -12,75 +21,134 @@
   export let viewportScale: number = 1;
   export let svgEl: SVGSVGElement;
 
+  let shiftPressed = false;
+
+  const ROTATION_HANDLE_OFFSET = 20 / viewportScale;
+
   $: geom = shape.geometry;
+  $: rotatedCorners = getRotatedCorners(geom.x, geom.y, geom.w, geom.h, geom.rot);
+  $: rotationHandlePos = getRotationHandlePosition(geom, ROTATION_HANDLE_OFFSET);
 
   const editor = (rectangle: Shape, handle: string, delta: [number, number]) => {
-    const initialBounds = rectangle.geometry.bounds;
-
-    let [x0, y0] = [initialBounds.minX, initialBounds.minY];
-    let [x1, y1] = [initialBounds.maxX, initialBounds.maxY];
+    let { x, y, w, h, rot } = (rectangle.geometry as RectangleGeometry);
 
     const [dx, dy] = delta;
 
-    if (handle === 'SHAPE') {
-      x0 += dx;
-      x1 += dx;
-      y0 += dy;
-      y1 += dy;
+    if (handle === 'ROTATION') {
+      const handlePos = getRotationHandlePosition(rectangle.geometry as RectangleGeometry, ROTATION_HANDLE_OFFSET);
+      
+      // Handle position after moving by delta
+      const currentHandleX = handlePos[0] + dx;
+      const currentHandleY = handlePos[1] + dy;
+
+      // Calculate the new rotation angle
+      const center: [number, number] = [x + w / 2, y + h / 2];
+      rot += angleFromPoints([handlePos[0], handlePos[1]], [currentHandleX, currentHandleY], center);
+      
+      // Snap to 10 degrees if SHIFT is held
+      if (shiftPressed)
+        rot = snapAngle(rot);
+    } else if (handle === 'SHAPE') {
+      // Moving the entire shape - translate it without rotation change
+      x += dx;
+      y += dy;
     } else {
+      // Edge or corner handle - resize in local (rotated) coordinate space
+      let localX0 = 0;
+      let localY0 = 0;
+      let localX1 = w;
+      let localY1 = h;
+
+      const [localDx, localDy] = rot !== 0 
+        ? transformDeltaToLocalCoords(dx, dy, rot)
+        : [dx, dy];
+
       switch (handle) {
         case 'TOP':
         case 'TOP_LEFT':
-        case 'TOP_RIGHT': {
-          y0 += dy;
+        case 'TOP_RIGHT':
+          localY0 += localDy;
           break;
-        }
-
         case 'BOTTOM':
         case 'BOTTOM_LEFT':
-        case 'BOTTOM_RIGHT': {
-          y1 += dy;
+        case 'BOTTOM_RIGHT':
+          localY1 += localDy;
           break;
-        }
       }
 
       switch (handle) {
         case 'LEFT':
         case 'TOP_LEFT':
-        case 'BOTTOM_LEFT': {
-          x0 += dx;
+        case 'BOTTOM_LEFT':
+          localX0 += localDx;
           break;
-        }
-
         case 'RIGHT':
         case 'TOP_RIGHT':
-        case 'BOTTOM_RIGHT': {
-          x1 += dx;
+        case 'BOTTOM_RIGHT':
+          localX1 += localDx;
           break;
-        }
       }
+
+      // The center shifts as edges move - calculate new center in local space
+      const newLocalCx = (localX0 + localX1) / 2;
+      const newLocalCy = (localY0 + localY1) / 2;
+
+      w = Math.abs(localX1 - localX0);
+      h = Math.abs(localY1 - localY0);
+
+      // Rotate the local center offset back to world space
+      const oldCenter: [number, number] = [
+        x + (rectangle.geometry as RectangleGeometry).w / 2, 
+        y + (rectangle.geometry as RectangleGeometry).h / 2
+      ];
+
+      const localCenterOffset: [number, number] = [
+        newLocalCx - (rectangle.geometry as RectangleGeometry).w / 2, 
+        newLocalCy - (rectangle.geometry as RectangleGeometry).h / 2
+      ];
+
+      const cos = Math.cos(rot);
+      const sin = Math.sin(rot);
+
+      const worldCx = oldCenter[0] + localCenterOffset[0] * cos - localCenterOffset[1] * sin;
+      const worldCy = oldCenter[1] + localCenterOffset[0] * sin + localCenterOffset[1] * cos;
+
+      x = worldCx - w / 2;
+      y = worldCy - h / 2;
     }
 
-    const x = Math.min(x0, x1);
-    const y = Math.min(y0, y1);
-    const w = Math.abs(x1 - x0);
-    const h = Math.abs(y1 - y0);
+    // Calculate new bounds
+    const bounds = getBoundsFromRotatedRect(x, y, w, h, rot);
 
     return {
       ...rectangle,
       geometry: {
-        x, y, w, h,
-        bounds: {
-          minX: x,
-          minY: y,
-          maxX: x + w,
-          maxY: y + h
-        }
+        x, y, w, h, rot,
+        bounds
       }
     };
   }
 
-  $: mask = getMaskDimensions(geom.bounds, 2 / viewportScale);
+  onMount(() => {
+    // Track SHIFT key
+    const onKeyDown = (evt: KeyboardEvent) => {
+      if (evt.key === 'Shift') shiftPressed = true;
+    }
+
+    const onKeyUp = (evt: KeyboardEvent) => {
+      if (evt.key === 'Shift') shiftPressed = false;
+    }
+
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+    };
+  });
+
+  $: mask = getMaskDimensions(geom.bounds, 5 / viewportScale);
   
   const maskId = `rect-mask-${Math.random().toString(36).substring(2, 12)}`;
 </script>
@@ -98,73 +166,129 @@
   <defs>
     <mask id={maskId} class="a9s-rectangle-editor-mask">
       <rect class="rect-mask-bg" x={mask.x} y={mask.y} width={mask.w} height={mask.h} />
-      <rect class="rect-mask-fg" x={geom.x} y={geom.y} width={geom.w} height={geom.h} />
+      <polygon
+        class="rect-mask-fg"
+        points={rotatedCorners.map(c => `${c[0]},${c[1]}`).join(' ')} />
     </mask>
   </defs>
 
-  <rect 
-    class="a9s-outer"
-    mask={`url(#${maskId})`}
-    on:pointerdown={grab('SHAPE')}
-    x={geom.x} y={geom.y} width={geom.w} height={geom.h} />
+  <!-- Rotation handle -->
+  <g>
+    <line
+      class="a9s-rotation-handle-line-bg"
+      x1={rotatedCorners[0][0] + (rotatedCorners[1][0] - rotatedCorners[0][0]) / 2}
+      y1={rotatedCorners[0][1] + (rotatedCorners[1][1] - rotatedCorners[0][1]) / 2}
+      x2={rotationHandlePos[0]}
+      y2={rotationHandlePos[1]}
+      pointer-events="none" />
 
-  <rect 
-    class="a9s-inner a9s-shape-handle"
-    style={computedStyle}
-    on:pointerdown={grab('SHAPE')}
-    x={geom.x} y={geom.y} width={geom.w} height={geom.h} />
+    <line
+      class="a9s-rotation-handle-line-fg"
+      x1={rotatedCorners[0][0] + (rotatedCorners[1][0] - rotatedCorners[0][0]) / 2}
+      y1={rotatedCorners[0][1] + (rotatedCorners[1][1] - rotatedCorners[0][1]) / 2}
+      x2={rotationHandlePos[0]}
+      y2={rotationHandlePos[1]}
+      pointer-events="none" />
 
-  <rect 
-    class="a9s-edge-handle a9s-edge-handle-top" 
-    on:pointerdown={grab('TOP')}
-    x={geom.x} y={geom.y} height={1} width={geom.w} />
+    <Handle
+      class="a9s-rotation-handle"
+      on:pointerdown={grab('ROTATION')}
+      x={rotationHandlePos[0]} y={rotationHandlePos[1]}
+      scale={viewportScale} />
+  </g>
 
-  <rect 
+  <!-- Rectangle shape -->
+  <g>
+    <polygon
+      class="a9s-outer"
+      mask={`url(#${maskId})`}
+      on:pointerdown={grab('SHAPE')}
+      points={rotatedCorners.map(c => `${c[0]},${c[1]}`).join(' ')} />
+
+    <polygon
+      class="a9s-inner a9s-shape-handle"
+      style={computedStyle}
+      on:pointerdown={grab('SHAPE')}
+      points={rotatedCorners.map(c => `${c[0]},${c[1]}`).join(' ')} />
+  </g>
+
+  <!-- Edge handles -->
+  <line
+    class="a9s-edge-handle a9s-edge-handle-top"
+    x1={rotatedCorners[0][0]} y1={rotatedCorners[0][1]}
+    x2={rotatedCorners[1][0]} y2={rotatedCorners[1][1]}
+    on:pointerdown={grab('TOP')} />
+
+  <line
     class="a9s-edge-handle a9s-edge-handle-right"
-    on:pointerdown={grab('RIGHT')}
-    x={geom.x + geom.w} y={geom.y} height={geom.h} width={1}/>
+    x1={rotatedCorners[1][0]} y1={rotatedCorners[1][1]}
+    x2={rotatedCorners[2][0]} y2={rotatedCorners[2][1]}
+    on:pointerdown={grab('RIGHT')} />
 
-  <rect 
-    class="a9s-edge-handle a9s-edge-handle-bottom" 
-    on:pointerdown={grab('BOTTOM')}
-    x={geom.x} y={geom.y + geom.h} height={1} width={geom.w} />
+  <line
+    class="a9s-edge-handle a9s-edge-handle-bottom"
+    x1={rotatedCorners[2][0]} y1={rotatedCorners[2][1]}
+    x2={rotatedCorners[3][0]} y2={rotatedCorners[3][1]}
+    on:pointerdown={grab('BOTTOM')} />
 
-  <rect 
-    class="a9s-edge-handle a9s-edge-handle-left" 
-    on:pointerdown={grab('LEFT')}
-    x={geom.x} y={geom.y} height={geom.h} width={1} />
+  <line
+    class="a9s-edge-handle a9s-edge-handle-left"
+    x1={rotatedCorners[3][0]} y1={rotatedCorners[3][1]}
+    x2={rotatedCorners[0][0]} y2={rotatedCorners[0][1]}
+    on:pointerdown={grab('LEFT')} />
 
+  <!-- Corner handles -->
   <Handle
     class="a9s-corner-handle-topleft"
     on:pointerdown={grab('TOP_LEFT')}
-    x={geom.x} y={geom.y}
+    x={rotatedCorners[0][0]} y={rotatedCorners[0][1]}
     scale={viewportScale} /> 
 
   <Handle
     class="a9s-corner-handle-topright"
     on:pointerdown={grab('TOP_RIGHT')}
-    x={geom.x + geom.w} y={geom.y} 
+    x={rotatedCorners[1][0]} y={rotatedCorners[1][1]} 
     scale={viewportScale} />
   
   <Handle 
     class="a9s-corner-handle-bottomright"
     on:pointerdown={grab('BOTTOM_RIGHT')}
-    x={geom.x + geom.w} y={geom.y + geom.h} 
+    x={rotatedCorners[2][0]} y={rotatedCorners[2][1]} 
     scale={viewportScale} />
     
   <Handle 
     class="a9s-corner-handle-bottomleft"
     on:pointerdown={grab('BOTTOM_LEFT')}
-    x={geom.x} y={geom.y + geom.h} 
+    x={rotatedCorners[3][0]} y={rotatedCorners[3][1]} 
     scale={viewportScale} />
 </Editor>
 
 <style>
-  mask.a9s-rectangle-editor-mask > rect.rect-mask-bg {
+  mask.a9s-rectangle-editor-mask rect.rect-mask-bg {
     fill: #fff;
   }
 
-  mask.a9s-rectangle-editor-mask > rect.rect-mask-fg {
+  mask.a9s-rectangle-editor-mask polygon.rect-mask-fg {
     fill: #000;
+  }
+
+  :global(.a9s-edge-handle) {
+    stroke-width: 4px;
+    stroke: rgba(0, 0, 0, 0.1);
+    pointer-events: stroke;
+    vector-effect: non-scaling-stroke;
+  }
+
+  :global(.a9s-rotation-handle-line-bg) {
+    stroke: rgba(0, 0, 0, 0.5);
+    stroke-width: 1.5px;
+    vector-effect: non-scaling-stroke;
+  }
+
+  :global(.a9s-rotation-handle-line-fg) {
+    stroke: #fff;
+    stroke-width: 1px;
+    stroke-dasharray: 3 1;
+    vector-effect: non-scaling-stroke;
   }
 </style>

--- a/packages/annotorious/src/annotation/editors/rectangle/RectangleEditor.svelte
+++ b/packages/annotorious/src/annotation/editors/rectangle/RectangleEditor.svelte
@@ -29,7 +29,7 @@
   $: rotationHandlePos = getRotationHandlePosition(geom, ROTATION_HANDLE_OFFSET);
 
   const editor = (rectangle: Shape, handle: string, delta: [number, number]) => {
-    let { x, y, w, h, rot } = (rectangle.geometry as RectangleGeometry);
+    let { x, y, w, h, rot = 0 } = (rectangle.geometry as RectangleGeometry);
 
     const [dx, dy] = delta;
 

--- a/packages/annotorious/src/annotation/editors/rectangle/RectangleEditor.svelte
+++ b/packages/annotorious/src/annotation/editors/rectangle/RectangleEditor.svelte
@@ -271,13 +271,6 @@
     fill: #000;
   }
 
-  :global(.a9s-edge-handle) {
-    stroke-width: 4px;
-    stroke: rgba(0, 0, 0, 0.1);
-    pointer-events: stroke;
-    vector-effect: non-scaling-stroke;
-  }
-
   :global(.a9s-rotation-handle-line-bg) {
     stroke: rgba(0, 0, 0, 0.5);
     stroke-width: 1.5px;

--- a/packages/annotorious/src/annotation/editors/rectangle/rotationUtils.ts
+++ b/packages/annotorious/src/annotation/editors/rectangle/rotationUtils.ts
@@ -31,7 +31,7 @@ export const getRotatedCorners = (
   y: number,
   w: number,
   h: number,
-  rot: number
+  rot: number = 0
 ): [[number, number], [number, number], [number, number], [number, number]] => {
   const corners: [number, number][] = [
     [x, y],
@@ -52,7 +52,7 @@ export const getRotatedCorners = (
 export const getRotationHandlePosition = (
   geom: RectangleGeometry, offset: number
 ): [number, number] => {
-  const { x , y, w, h, rot } = geom;
+  const { x , y, w, h, rot = 0 } = geom;
   const center: [number, number] = [x + w / 2, y + h / 2];
   let topCenter: [number, number] = [x + w / 2, y - offset];
   return rotatePoint(topCenter, center, rot);

--- a/packages/annotorious/src/annotation/editors/rectangle/rotationUtils.ts
+++ b/packages/annotorious/src/annotation/editors/rectangle/rotationUtils.ts
@@ -46,28 +46,6 @@ export const getRotatedCorners = (
 }
 
 /** 
- * Calculates the axis-aligned bounding box of a rotated rectangle.
- */
-export const getBoundsFromRotatedRect = (
-  x: number,
-  y: number,
-  w: number,
-  h: number,
-  rot: number
-): Bounds => {
-  const corners = getRotatedCorners(x, y, w, h, rot);
-  const xs = corners.map(c => c[0]);
-  const ys = corners.map(c => c[1]);
-
-  return {  
-    minX: Math.min(...xs),
-    minY: Math.min(...ys),
-    maxX: Math.max(...xs),
-    maxY: Math.max(...ys)
-  };
-}
-
-/** 
  * Calculates the position of the rotation handle.
  */
 export const getRotationHandlePosition = (

--- a/packages/annotorious/src/annotation/editors/rectangle/rotationUtils.ts
+++ b/packages/annotorious/src/annotation/editors/rectangle/rotationUtils.ts
@@ -10,6 +10,7 @@ export const rotatePoint = (
 ): [number, number] => {
   const [px, py] = point;
   const [cx, cy] = center;
+  
   const cos = Math.cos(angle);
   const sin = Math.sin(angle);
 

--- a/packages/annotorious/src/annotation/editors/rectangle/rotationUtils.ts
+++ b/packages/annotorious/src/annotation/editors/rectangle/rotationUtils.ts
@@ -98,7 +98,7 @@ export const transformDeltaToLocalCoords = (
 }
 
 /**
- * Calculates the rotation angle between a point and the origin, relative to a center
+ * Calculates the rotation angle between a point and the origin, relative to a center.
  */
 export const angleFromPoints = (
   point1: [number, number],
@@ -114,47 +114,6 @@ export const angleFromPoints = (
   const angle2 = Math.atan2(dy2, dx2);
 
   return angle2 - angle1;
-}
-
-/**
- * Normalizes a rectangle's rotation to the range [0, π/2)
- * When rotation >= π/2, swaps width/height and adjusts position to keep center fixed
- */
-export const normalizeRotation = (
-  x: number,
-  y: number,
-  w: number,
-  h: number,
-  rot: number
-): {
-  x: number;
-  y: number;
-  w: number;
-  h: number;
-  rot: number;
-} => {
-  let angle = rot;
-  let width = w;
-  let height = h;
-  let posX = x;
-  let posY = y;
-
-  // Normalize angle to [0, π/2)
-  while (angle >= Math.PI / 2) {
-    angle -= Math.PI / 2;
-
-    const centerX = posX + width / 2;
-    const centerY = posY + height / 2;
-
-    // Swap width and height
-    [width, height] = [height, width];
-
-    // Recalculate position to keep center fixed
-    posX = centerX - width / 2;
-    posY = centerY - height / 2;
-  }
-
-  return { x: posX, y: posY, w: width, h: height, rot: angle };
 }
 
 /**

--- a/packages/annotorious/src/annotation/editors/rectangle/rotationUtils.ts
+++ b/packages/annotorious/src/annotation/editors/rectangle/rotationUtils.ts
@@ -1,0 +1,166 @@
+import type { Bounds, RectangleGeometry } from '../../../model';
+
+/**
+ * Rotates a point around a center by the given angle (in rad).
+ */
+export const rotatePoint = (
+  point: [number, number],
+  center: [number, number],
+  angle: number
+): [number, number] => {
+  const [px, py] = point;
+  const [cx, cy] = center;
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+
+  const dx = px - cx;
+  const dy = py - cy;
+
+  return [
+    cx + dx * cos - dy * sin,
+    cy + dx * sin + dy * cos
+  ];
+}
+
+/**
+ * Gets the four corner points of a rotated rectangle in world space.
+ */
+export const getRotatedCorners = (
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  rot: number
+): [[number, number], [number, number], [number, number], [number, number]] => {
+  const corners: [number, number][] = [
+    [x, y],
+    [x + w, y],
+    [x + w, y + h],
+    [x, y + h]
+  ];
+
+  const center: [number, number] = [x + w / 2, y + h / 2];
+
+  return corners.map(corner => 
+    rotatePoint(corner, center, rot)) as [[number, number], [number, number], [number, number], [number, number]];
+}
+
+/** 
+ * Calculates the axis-aligned bounding box of a rotated rectangle.
+ */
+export const getBoundsFromRotatedRect = (
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  rot: number
+): Bounds => {
+  const corners = getRotatedCorners(x, y, w, h, rot);
+  const xs = corners.map(c => c[0]);
+  const ys = corners.map(c => c[1]);
+
+  return {  
+    minX: Math.min(...xs),
+    minY: Math.min(...ys),
+    maxX: Math.max(...xs),
+    maxY: Math.max(...ys)
+  };
+}
+
+/** 
+ * Calculates the position of the rotation handle.
+ */
+export const getRotationHandlePosition = (
+  geom: RectangleGeometry, offset: number
+): [number, number] => {
+  const { x , y, w, h, rot } = geom;
+  const center: [number, number] = [x + w / 2, y + h / 2];
+  let topCenter: [number, number] = [x + w / 2, y - offset];
+  return rotatePoint(topCenter, center, rot);
+}
+
+/**
+ * Transforms a movement delta from world coords to the rectangle's 
+ * local (non-rotated) coordinate system.
+ */
+export const transformDeltaToLocalCoords = (
+  deltaX: number,
+  deltaY: number,
+  rot: number
+): [number, number] => {
+  const cos = Math.cos(rot);
+  const sin = Math.sin(rot);
+
+  return [
+    deltaX * cos + deltaY * sin,
+    -deltaX * sin + deltaY * cos
+  ];
+}
+
+/**
+ * Calculates the rotation angle between a point and the origin, relative to a center
+ */
+export const angleFromPoints = (
+  point1: [number, number],
+  point2: [number, number],
+  center: [number, number]
+): number => {
+  const dx1 = point1[0] - center[0];
+  const dy1 = point1[1] - center[1];
+  const angle1 = Math.atan2(dy1, dx1);
+
+  const dx2 = point2[0] - center[0];
+  const dy2 = point2[1] - center[1];
+  const angle2 = Math.atan2(dy2, dx2);
+
+  return angle2 - angle1;
+}
+
+/**
+ * Normalizes a rectangle's rotation to the range [0, π/2)
+ * When rotation >= π/2, swaps width/height and adjusts position to keep center fixed
+ */
+export const normalizeRotation = (
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  rot: number
+): {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  rot: number;
+} => {
+  let angle = rot;
+  let width = w;
+  let height = h;
+  let posX = x;
+  let posY = y;
+
+  // Normalize angle to [0, π/2)
+  while (angle >= Math.PI / 2) {
+    angle -= Math.PI / 2;
+
+    const centerX = posX + width / 2;
+    const centerY = posY + height / 2;
+
+    // Swap width and height
+    [width, height] = [height, width];
+
+    // Recalculate position to keep center fixed
+    posX = centerX - width / 2;
+    posY = centerY - height / 2;
+  }
+
+  return { x: posX, y: posY, w: width, h: height, rot: angle };
+}
+
+/**
+ * Snaps an angle to the nearest 45-degree increment
+ */
+export const snapAngle = (angle: number, inc = 10): number => {
+  const step = (inc * Math.PI) / 180;
+  return Math.round(angle / step) * step;
+}

--- a/packages/annotorious/src/annotation/shapes/Rectangle.svelte
+++ b/packages/annotorious/src/annotation/shapes/Rectangle.svelte
@@ -10,23 +10,30 @@
 
   $: computedStyle = computeStyle(annotation, style);
 
-  $: ({ x, y, w, h } = geom as RectangleGeometry);
+  $: ({ x, y, w, h, rot } = geom as RectangleGeometry);
+
+  // Calculate transform for rotation
+  $: rectTransform = rot !== 0 ? 
+    `translate(${x + w / 2}, ${y + h / 2}) rotate(${(rot * 180) / Math.PI}) translate(${-(x + w / 2)}, ${-(y + h / 2)})` :
+    undefined;
 </script>
 
 <g class="a9s-annotation" data-id={annotation.id}>
-  <rect
-    class="a9s-outer"
-    style={computedStyle ? 'display:none;' : undefined}
-    x={x} 
-    y={y} 
-    width={w} 
-    height={h} />
+  <g transform={rectTransform}>
+    <rect
+      class="a9s-outer"
+      style={computedStyle ? 'display:none;' : undefined}
+      x={x} 
+      y={y} 
+      width={w} 
+      height={h} />
 
-  <rect
-    class="a9s-inner"
-    style={computedStyle}
-    x={x} 
-    y={y} 
-    width={w} 
-    height={h} />
+    <rect
+      class="a9s-inner"
+      style={computedStyle}
+      x={x} 
+      y={y} 
+      width={w} 
+      height={h} />
+  </g>
 </g>

--- a/packages/annotorious/src/annotation/shapes/Rectangle.svelte
+++ b/packages/annotorious/src/annotation/shapes/Rectangle.svelte
@@ -13,8 +13,8 @@
   $: ({ x, y, w, h, rot } = geom as RectangleGeometry);
 
   // Calculate transform for rotation
-  $: rectTransform = rot !== 0 ? 
-    `translate(${x + w / 2}, ${y + h / 2}) rotate(${(rot * 180) / Math.PI}) translate(${-(x + w / 2)}, ${-(y + h / 2)})` :
+  $: rectTransform = (rot ?? 0) !== 0 ? 
+    `translate(${x + w / 2}, ${y + h / 2}) rotate(${((rot ?? 0) * 180) / Math.PI}) translate(${-(x + w / 2)}, ${-(y + h / 2)})` :
     undefined;
 </script>
 

--- a/packages/annotorious/src/annotation/tools/rectangle/RubberbandRectangle.svelte
+++ b/packages/annotorious/src/annotation/tools/rectangle/RubberbandRectangle.svelte
@@ -106,6 +106,7 @@
             maxX: x + w,
             maxY: y + h
           },
+          rot: 0,
           x, y, w, h
         }
       }

--- a/packages/annotorious/src/model/core/rectangle/Rectangle.ts
+++ b/packages/annotorious/src/model/core/rectangle/Rectangle.ts
@@ -16,6 +16,8 @@ export interface RectangleGeometry extends Geometry {
 
   h: number;
 
+  rot: number;
+
   bounds: Bounds;
 
 }

--- a/packages/annotorious/src/model/core/rectangle/Rectangle.ts
+++ b/packages/annotorious/src/model/core/rectangle/Rectangle.ts
@@ -16,7 +16,7 @@ export interface RectangleGeometry extends Geometry {
 
   h: number;
 
-  rot: number;
+  rot?: number;
 
   bounds: Bounds;
 

--- a/packages/annotorious/src/model/core/rectangle/rectangleUtils.ts
+++ b/packages/annotorious/src/model/core/rectangle/rectangleUtils.ts
@@ -6,11 +6,37 @@ export const RectangleUtil: ShapeUtil<Rectangle> = {
 
   area: (rect: Rectangle): number => rect.geometry.w * rect.geometry.h,
 
-  intersects: (rect: Rectangle, x: number, y: number): boolean =>
-    x >= rect.geometry.x &&
-    x <= rect.geometry.x + rect.geometry.w &&
-    y >= rect.geometry.y &&
-    y <= rect.geometry.y + rect.geometry.h
+  intersects: (rect: Rectangle, x: number, y: number): boolean => {
+    const geom = rect.geometry;
+    
+    if (geom.rot === 0) {
+      return x >= geom.x &&
+        x <= geom.x + geom.w &&
+        y >= geom.y &&
+        y <= geom.y + geom.h;
+    } else {
+      // For rotated rectangles, transform the test point to local coordinates
+      const centerX = geom.x + geom.w / 2;
+      const centerY = geom.y + geom.h / 2;
+
+      // Translate point relative to center
+      const dx = x - centerX;
+      const dy = y - centerY;
+
+      // Rotate backwards to get to local (non-rotated) coordinates
+      const cos = Math.cos(geom.rot);
+      const sin = Math.sin(geom.rot);
+
+      const localX = dx * cos + dy * sin;
+      const localY = -dx * sin + dy * cos;
+
+      // Check if point is within rectangle bounds in local space
+      return localX >= -geom.w / 2 &&
+        localX <= geom.w / 2 &&
+        localY >= -geom.h / 2 &&
+        localY <= geom.h / 2;
+    } 
+  }
     
 };
 

--- a/packages/annotorious/src/model/core/rectangle/rectangleUtils.ts
+++ b/packages/annotorious/src/model/core/rectangle/rectangleUtils.ts
@@ -9,7 +9,7 @@ export const RectangleUtil: ShapeUtil<Rectangle> = {
   intersects: (rect: Rectangle, x: number, y: number): boolean => {
     const geom = rect.geometry;
     
-    if (geom.rot === 0) {
+    if (!geom.rot) {
       return x >= geom.x &&
         x <= geom.x + geom.w &&
         y >= geom.y &&

--- a/packages/annotorious/src/model/w3c/W3CImageFormatAdapter.ts
+++ b/packages/annotorious/src/model/w3c/W3CImageFormatAdapter.ts
@@ -103,14 +103,16 @@ export const serializeW3CImageAnnotation = (
   let w3cSelector: FragmentSelector | SVGSelector | unknown;
 
   try {
-    w3cSelector = selector.type == ShapeType.RECTANGLE ?
-      serializeFragmentSelector(selector.geometry as RectangleGeometry) :
-      serializeSVGSelector(selector);
+    if (selector.type === ShapeType.RECTANGLE && (selector.geometry as RectangleGeometry).rot === 0) {
+      w3cSelector = serializeFragmentSelector(selector.geometry as RectangleGeometry);
+    } else {
+      w3cSelector = serializeSVGSelector(selector);
+    }
   } catch (error) {
     if (opts.strict)
       throw error;
     else 
-     w3cSelector = selector;
+      w3cSelector = selector;
   }
 
   const serialized = {

--- a/packages/annotorious/src/model/w3c/W3CImageFormatAdapter.ts
+++ b/packages/annotorious/src/model/w3c/W3CImageFormatAdapter.ts
@@ -103,7 +103,7 @@ export const serializeW3CImageAnnotation = (
   let w3cSelector: FragmentSelector | SVGSelector | unknown;
 
   try {
-    if (selector.type === ShapeType.RECTANGLE && (selector.geometry as RectangleGeometry).rot === 0) {
+    if (selector.type === ShapeType.RECTANGLE && !(selector.geometry as RectangleGeometry).rot) {
       w3cSelector = serializeFragmentSelector(selector.geometry as RectangleGeometry);
     } else {
       w3cSelector = serializeSVGSelector(selector);

--- a/packages/annotorious/src/model/w3c/fragment/FragmentSelector.ts
+++ b/packages/annotorious/src/model/w3c/fragment/FragmentSelector.ts
@@ -55,6 +55,7 @@ export const parseFragmentSelector = (
       y,
       w,
       h,
+      rot: 0,
       bounds: {
         minX: x,
         minY: invertY ? y - h : y,

--- a/packages/annotorious/src/model/w3c/svg/SVGSelector.ts
+++ b/packages/annotorious/src/model/w3c/svg/SVGSelector.ts
@@ -241,7 +241,7 @@ export const serializeSVGSelector = (shape: Shape): SVGSelector => {
       } else {
         const cx = x + w / 2;
         const cy = y + h / 2;
-        const angle = (rot * 180) / Math.PI;
+        const angle = ((rot ?? 0) * 180) / Math.PI;
 
         value = `<svg><rect x="${x}" y="${y}" width="${w}" height="${h}" transform="rotate(${angle} ${cx} ${cy})" /></svg>`;
       }

--- a/packages/annotorious/src/model/w3c/svg/SVGSelector.ts
+++ b/packages/annotorious/src/model/w3c/svg/SVGSelector.ts
@@ -236,7 +236,7 @@ export const serializeSVGSelector = (shape: Shape): SVGSelector => {
       const geom = shape.geometry as RectangleGeometry;
       const { x, y, w, h, rot } = geom;
 
-      if (rot === 0) {
+      if (!rot) {
         value = `<svg><rect x="${x}" y="${y}" width="${w}" height="${h}" /></svg>`;
       } else {
         const cx = x + w / 2;

--- a/packages/annotorious/src/model/w3c/svg/SVGSelector.ts
+++ b/packages/annotorious/src/model/w3c/svg/SVGSelector.ts
@@ -12,6 +12,8 @@ import type {
   PolygonGeometry, 
   Polyline,
   PolylineGeometry, 
+  Rectangle,
+  RectangleGeometry,
   Shape 
 } from '../../core';
 
@@ -107,6 +109,68 @@ const parseSVGPathToPolyline = (value: string): Polyline => {
   }
 }
 
+const parseSVGRect = (value: string): Rectangle => {
+  const doc = parseSVGXML(value);
+
+  const rect = doc.nodeName === 'rect' ? doc : Array.from(doc.querySelectorAll('rect'))[0];
+  if (!rect) throw new Error('Could not parse SVG rect');
+
+  const x = parseFloat(rect.getAttribute('x')!);
+  const y = parseFloat(rect.getAttribute('y')!);
+  const w = parseFloat(rect.getAttribute('width')!);
+  const h = parseFloat(rect.getAttribute('height')!);
+
+  const transform = rect.getAttribute('transform');
+  let rot = 0;
+
+  if (transform && transform.startsWith('rotate(')) {
+    const match = transform.match(/rotate\(([^)]+)\)/);
+    if (match) {
+      const params = match[1].split(/\s+/).map(parseFloat);
+      rot = (params[0] * Math.PI) / 180;
+    }
+  }
+
+  // Compute bounds
+  const cx = x + w / 2;
+  const cy = y + h / 2;
+
+  const corners = [
+    [x, y],
+    [x + w, y],
+    [x + w, y + h],
+    [x, y + h]
+  ];
+
+  // Rotate corners around center
+  const rotatedCorners = corners.map(([px, py]) => {
+    const dx = px - cx;
+    const dy = py - cy;
+
+    const cos = Math.cos(rot);
+    const sin = Math.sin(rot);
+
+    return [
+      cx + dx * cos - dy * sin,
+      cy + dx * sin + dy * cos
+    ];
+  });
+
+  const bounds = boundsFromPoints(rotatedCorners as [number, number][]);
+
+  return {
+    type: ShapeType.RECTANGLE,
+    geometry: {
+      x,
+      y,
+      w,
+      h,
+      rot,
+      bounds
+    }
+  };
+}
+
 const parseSVGPathToPolygon = (value: string): Polygon | MultiPolygon => {
   const doc = parseSVGXML(value);
 
@@ -151,6 +215,8 @@ export const parseSVGSelector = <T extends Shape>(valueOrSelector: SVGSelector |
     return parseSVGEllipse(value) as unknown as T;
   else if (value.includes("<line "))
     return parseSVGLine(value) as unknown as T;
+  else if (value.includes('<rect '))
+    return parseSVGRect(value) as unknown as T;
   else 
     throw 'Unsupported SVG shape: ' + value;
 }
@@ -166,6 +232,21 @@ export const serializeSVGSelector = (shape: Shape): SVGSelector => {
   let value: string | undefined;
 
   switch (shape.type) {
+    case ShapeType.RECTANGLE: {
+      const geom = shape.geometry as RectangleGeometry;
+      const { x, y, w, h, rot } = geom;
+
+      if (rot === 0) {
+        value = `<svg><rect x="${x}" y="${y}" width="${w}" height="${h}" /></svg>`;
+      } else {
+        const cx = x + w / 2;
+        const cy = y + h / 2;
+        const angle = (rot * 180) / Math.PI;
+
+        value = `<svg><rect x="${x}" y="${y}" width="${w}" height="${h}" transform="rotate(${angle} ${cx} ${cy})" /></svg>`;
+      }
+      break;
+    }
     case ShapeType.POLYGON: {
       const geom = shape.geometry as PolygonGeometry;
       const { points } = geom;

--- a/packages/annotorious/src/state/spatialTree.ts
+++ b/packages/annotorious/src/state/spatialTree.ts
@@ -83,11 +83,8 @@ export const createSpatialTree = () => {
       maxY: y + buffer
     }).map(item => item.target);
 
-    // Exact hit test on shape (not needed for rectangles!)
-    const exactHits = idxHits.filter(target => {
-      return (target.selector.type === ShapeType.RECTANGLE) ||
-        intersects(target.selector, x, y, buffer);
-    });
+    // Exact hit test on shape
+    const exactHits = idxHits.filter(({ selector }) => intersects(selector, x, y, buffer));
 
     // Get smallest shape
     if (exactHits.length > 0) {

--- a/packages/annotorious/test/annotations.core.json
+++ b/packages/annotorious/test/annotations.core.json
@@ -1,5 +1,32 @@
 [
   {
+    "id": "abf9a4c5-1f11-43a3-ba3e-ce94b58eeb6d",
+    "bodies": [],
+    "target": {
+      "annotation": "abf9a4c5-1f11-43a3-ba3e-ce94b58eeb6d",
+      "selector": {
+        "type": "RECTANGLE",
+        "geometry": {
+          "x": 403.94140625,
+          "y": 38.84765625,
+          "w": 102.90625,
+          "h": 61.65234375,
+          "bounds": {
+            "minX": 403.44921875,
+            "minY": 39.99609375,
+            "maxX": 506.35546875,
+            "maxY": 101.6484375
+          }
+        }
+      },
+      "creator": {
+        "isGuest": true,
+        "id": "eKpPZYO4wHYY5dBwNmlR"
+      },
+      "created": "2026-03-16T06:32:46.822Z"
+    }
+  },
+  {
     "id": "ec2dbf64-58fd-4b38-a096-d98243d78423",
     "bodies": [],
     "target": {

--- a/packages/annotorious/test/annotations.w3c.json
+++ b/packages/annotorious/test/annotations.w3c.json
@@ -1,4 +1,4 @@
-[ 
+[
   {
     "@context": "http://www.w3.org/ns/anno.jsonld",
     "id": "e23b9018-54ed-495b-be64-9743f022e042",
@@ -18,7 +18,21 @@
       ]
     }
   },
-    {
+  {
+    "@context": "http://www.w3.org/ns/anno.jsonld",
+    "id": "655b3800-3020-4f94-b6fc-17f5f6cd085e",
+    "type": "Annotation",
+    "body": [],
+    "target": {
+      "source": "sample-image",
+      "type": "SpecificResource",
+      "selector": {
+        "type": "SvgSelector",
+        "value": "<svg><rect x=\"427.69921875\" y=\"258.79296875\" width=\"134.64453125\" height=\"55.453125\" transform=\"rotate(21.421795454004197 495.021484375 286.51953125)\" /></svg>"
+      }
+    }
+  },
+  {
     "@context": "http://www.w3.org/ns/anno.jsonld",
     "id": "ce06734b-cc9a-462e-bb9f-b8c22c8c807d",
     "type": "Annotation",

--- a/packages/annotorious/test/index.html
+++ b/packages/annotorious/test/index.html
@@ -71,8 +71,6 @@
           // console.log('leave', annotation);
         });
 
-        anno.setDrawingTool('polygon');
-
         document.addEventListener('keydown', evt => {
           if (evt.key === 'Escape')
             anno.cancelDrawing();

--- a/packages/annotorious/test/index.html
+++ b/packages/annotorious/test/index.html
@@ -35,7 +35,7 @@
 
       window.onload = function() {
         var anno = createImageAnnotator('sample-image', {
-          // adapter: W3CImageFormat('sample-image'),
+          adapter: W3CImageFormat('sample-image'),
           autoSave: true,
           style: function(annotation) {
             return annotation.target.selector.type === 'RECTANGLE' 
@@ -44,7 +44,7 @@
           }
         });
 
-        // anno.loadAnnotations('./annotations.w3c.json');
+        anno.loadAnnotations('./annotations.w3c.json');
         // anno.loadAnnotations('./annotations.core.json');
       
         anno.on('createAnnotation', function (annotation) {

--- a/packages/annotorious/test/index.html
+++ b/packages/annotorious/test/index.html
@@ -35,7 +35,7 @@
 
       window.onload = function() {
         var anno = createImageAnnotator('sample-image', {
-          adapter: W3CImageFormat('sample-image'),
+          // adapter: W3CImageFormat('sample-image'),
           autoSave: true,
           style: function(annotation) {
             return annotation.target.selector.type === 'RECTANGLE' 

--- a/packages/annotorious/test/index.html
+++ b/packages/annotorious/test/index.html
@@ -35,7 +35,7 @@
 
       window.onload = function() {
         var anno = createImageAnnotator('sample-image', {
-          adapter: W3CImageFormat('sample-image'),
+          // adapter: W3CImageFormat('sample-image'),
           autoSave: true,
           style: function(annotation) {
             return annotation.target.selector.type === 'RECTANGLE' 
@@ -44,8 +44,8 @@
           }
         });
 
-        anno.loadAnnotations('./annotations.w3c.json');
-        // anno.loadAnnotations('./annotations.core.json');
+        // anno.loadAnnotations('./annotations.w3c.json');
+        anno.loadAnnotations('./annotations.core.json');
       
         anno.on('createAnnotation', function (annotation) {
           console.log('created', annotation);

--- a/packages/annotorious/test/model/w3c/W3CImageFormatAdapter.test.ts
+++ b/packages/annotorious/test/model/w3c/W3CImageFormatAdapter.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { W3CAnnotation } from '@annotorious/core';
-import { parseW3CImageAnnotation, Polyline, serializeW3CImageAnnotation, ShapeType, W3CImageAnnotation } from '../../../src/model';
+import { 
+  parseW3CImageAnnotation, 
+  type Polyline, 
+  type RectangleGeometry, 
+  serializeW3CImageAnnotation, 
+  ShapeType, 
+  type W3CImageAnnotation, 
+  type W3CImageAnnotationTarget, 
+  type W3CImageSelector 
+} from '../../../src/model';
 
 import { annotations } from './fixtures';
 
@@ -80,6 +89,60 @@ describe('serializeW3CImageAnnotation', () => {
       expect(a.id).toBe(e.id);
       expect('bodies' in a).toBeFalsy();
     })
-  })
+  });
+
+  it('should serialize axis-aligned rectangles as FragmentSelector', () => {
+    const annotation = {
+      id: 'test-rect',
+      bodies: [],
+      target: {
+        annotation: 'test-rect',
+        selector: {
+          type: ShapeType.RECTANGLE,
+          geometry: {
+            x: 10,
+            y: 20,
+            w: 100,
+            h: 50,
+            rot: 0,
+            bounds: { minX: 10, minY: 20, maxX: 110, maxY: 70 }
+          } as RectangleGeometry
+        }
+      }
+    };
+
+    const serialized = serializeW3CImageAnnotation(annotation, 'http://example.com/image');
+    const selector = (serialized.target as W3CImageAnnotationTarget).selector as W3CImageSelector;
+
+    expect(selector.type).toBe('FragmentSelector');
+    expect(selector.value).toBe('xywh=pixel:10,20,100,50');
+  });
+
+  it('should serialize rotated rectangles as SvgSelector', () => {
+    const annotation = {
+      id: 'test-rotated-rect',
+      bodies: [],
+      target: {
+        annotation: 'test-rotated-rect',
+        selector: {
+          type: ShapeType.RECTANGLE,
+          geometry: {
+            x: 10,
+            y: 20,
+            w: 100,
+            h: 50,
+            rot: Math.PI / 4, // 45 degrees
+            bounds: { minX: 10, minY: 20, maxX: 110, maxY: 70 }
+          }
+        }
+      }
+    };
+
+    const serialized = serializeW3CImageAnnotation(annotation, 'http://example.com/image');
+    const selector = (serialized.target as W3CImageAnnotationTarget).selector as W3CImageSelector;
+
+    expect(selector.type).toBe('SvgSelector');
+    expect(selector.value).toContain('<rect x="10" y="20" width="100" height="50" transform="rotate(45 60 45)"');
+  });
 });
 

--- a/packages/annotorious/test/model/w3c/fragment/FragmentSelector.test.ts
+++ b/packages/annotorious/test/model/w3c/fragment/FragmentSelector.test.ts
@@ -4,12 +4,13 @@ import { parseFragmentSelector } from '../../../../src/model/w3c/fragment';
 describe('parseFragmentSelector', () => {
   it('should parse a fragment with pixel unit correctly', () => {
     const fragment = 'xywh=pixel:160,120,320,240';
-    const { geometry: { x, y, w, h, bounds } } = parseFragmentSelector(fragment);
+    const { geometry: { x, y, w, h, rot, bounds } } = parseFragmentSelector(fragment);
 
     expect(x).toBe(160);
     expect(y).toBe(120);
     expect(w).toBe(320);
     expect(h).toBe(240);
+    expect(rot).toBe(0);
 
     expect(bounds.minX).toBe(160);
     expect(bounds.minY).toBe(120);
@@ -19,12 +20,13 @@ describe('parseFragmentSelector', () => {
 
   it('should parse a fragment without unit as pixel fragment', () => {
     const fragment = 'xywh=160,120,320,240';
-    const { geometry: { x, y, w, h, bounds } } = parseFragmentSelector(fragment);
+    const { geometry: { x, y, w, h, rot, bounds } } = parseFragmentSelector(fragment);
 
     expect(x).toBe(160);
     expect(y).toBe(120);
     expect(w).toBe(320);
     expect(h).toBe(240);
+    expect(rot).toBe(0);
 
     expect(bounds.minX).toBe(160);
     expect(bounds.minY).toBe(120);
@@ -34,12 +36,13 @@ describe('parseFragmentSelector', () => {
 
   it('should parse a fragment with negative values', () => {
     const fragment = 'xywh=160,-120,320,240';
-    const { geometry: { x, y, w, h, bounds } } = parseFragmentSelector(fragment);
+    const { geometry: { x, y, w, h, rot, bounds } } = parseFragmentSelector(fragment);
 
     expect(x).toBe(160);
     expect(y).toBe(-120);
     expect(w).toBe(320);
     expect(h).toBe(240);
+    expect(rot).toBe(0);
 
     expect(bounds.minX).toBe(160);
     expect(bounds.minY).toBe(-120);


### PR DESCRIPTION
## In this PR

This PR adds functionality for **rotating rectangle shapes** (issue #344).

* In the core data model, a `rot` field was added to the rectangle geometry object (radian angle). (Note that the `bounds` field remains unchanged, but is defined as the bounds covered by the rotated rectangle!)
* SVG (standard image) and Pixi (OSD) renderers were updated.
* The spatial index was updated to take rotation into account for intersection and hit testing.
* The W3C format adapter keeps serializing (and parsing) rectangles as `FragmentSelector` if `rot` is 0; and serializes an SVG `rect` with a `transform` if the rectangle has rotation.
* The drawing tool was extended with an extra "rotation handle". Holding SHIFT while dragging the handle snaps rotation to 10 degree increments.