### PR TITLE
Anchored regex + strict numeric parsing for W3C FragmentSelector

### DIFF
--- a/packages/annotorious/src/model/w3c/fragment/FragmentSelector.ts
+++ b/packages/annotorious/src/model/w3c/fragment/FragmentSelector.ts
@@ -11,6 +11,23 @@ export interface FragmentSelector {
 
 }
 
+const NUMBER = '-?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?';
+
+// Anchored, numeric-only pattern. Avoids the broad lazy + nested quantifier
+// shapes that allowed pathological backtracking on adversarial input.
+const XYWH_RE = new RegExp(
+  `^xywh=(?:(pixel|percent):)?(${NUMBER}),(${NUMBER}),(${NUMBER}),(${NUMBER})$`,
+  'i'
+);
+
+// Strip everything up to and including the first '#xywh=' for URI-style inputs
+// like "https://example.org/image.jpg#xywh=...". Returns the bare fragment when
+// no hash is present.
+const stripHash = (s: string): string => {
+  const idx = s.indexOf('#xywh=');
+  return idx < 0 ? s : s.slice(idx + 1);
+}
+
 export const isFragmentSelector = (
   selector: any
 ): boolean => {
@@ -18,11 +35,8 @@ export const isFragmentSelector = (
     return true;
 
   if (typeof selector === 'string') {
-    const hashIndex = selector.indexOf('#');
-    if (hashIndex < 0) return false;
-
-    const xywh = /#xywh(?:=(?:pixel:|percent:)?)(.+?),(.+?),(.+?),(.+)$/i;
-    return xywh.test(selector);
+    if (selector.indexOf('#xywh=') < 0) return false;
+    return XYWH_RE.test(stripHash(selector));
   }
 
   return false;
@@ -32,21 +46,20 @@ export const parseFragmentSelector = (
   fragmentOrSelector: FragmentSelector | string,
   invertY = false
 ): Rectangle => {
-  const fragment =
+  const raw =
     typeof fragmentOrSelector === 'string' ? fragmentOrSelector : fragmentOrSelector.value;
 
-  const regex = /(xywh)=(?:(pixel|percent):)?:?(.+?),(.+?),(.+?),(.+)*/g;
-  const matches = [...fragment.matchAll(regex)][0];
+  const fragment = stripHash(raw);
 
-  if (!matches) throw new Error('Not a MediaFragment: ' + fragment);
+  const matches = XYWH_RE.exec(fragment);
 
-  const [_, prefix, unit, a, b, c, d] = matches;
+  if (!matches) throw new Error('Not a MediaFragment: ' + raw);
 
-  if (prefix !== 'xywh') throw new Error('Unsupported MediaFragment: ' + fragment);
+  const [, unit, a, b, c, d] = matches;
 
   if (unit && unit !== 'pixel') throw new Error(`Unsupported MediaFragment unit: ${unit}`);
 
-  const [x, y, w, h] = [a, b, c, d].map(parseFloat);
+  const [x, y, w, h] = [a, b, c, d].map(Number);
 
   return {
     type: ShapeType.RECTANGLE,

--- a/packages/annotorious/test/model/w3c/fragment/FragmentSelector.test.ts
+++ b/packages/annotorious/test/model/w3c/fragment/FragmentSelector.test.ts
@@ -68,5 +68,42 @@ describe('parseFragmentSelector', () => {
     } catch (error) {
       expect((error as Error).message.startsWith('Not a MediaFragment')).toBeTruthy();
     }
-  })
+  });
+
+  it('should reject malformed coordinate values rather than silently truncate them', () => {
+    expect(() => parseFragmentSelector('xywh=pixel:10abc,20def,30ghi,40jkl'))
+      .toThrow(/Not a MediaFragment/);
+  });
+
+  it('should parse adversarial input in bounded time', () => {
+    const payload = 'xywh='.repeat(16000) + '\nxywh=1,2,3,4';
+
+    const start = performance.now();
+    try {
+      parseFragmentSelector(payload);
+    } catch {
+      // Rejection is the correct outcome; what matters is the bounded time.
+    }
+    const elapsed = performance.now() - start;
+
+    expect(elapsed).toBeLessThan(50);
+  });
+
+  it('should parse decimal coordinates', () => {
+    const { geometry: { x, y, w, h } } = parseFragmentSelector('xywh=10.5,20.25,30,40');
+
+    expect(x).toBe(10.5);
+    expect(y).toBe(20.25);
+    expect(w).toBe(30);
+    expect(h).toBe(40);
+  });
+
+  it('should parse a URI fragment with #xywh=', () => {
+    const { geometry: { x, y, w, h } } = parseFragmentSelector('https://example.com/image.jpg#xywh=10,20,30,40');
+
+    expect(x).toBe(10);
+    expect(y).toBe(20);
+    expect(w).toBe(30);
+    expect(h).toBe(40);
+  });
 });


### PR DESCRIPTION
## In this PR

Addresses #603.

The W3C `FragmentSelector` parser used a non-anchored regex with broad
lazy groups and a nested quantifier (`(.+?),(.+?),(.+?),(.+)*`). On
crafted inputs like `'xywh='.repeat(n) + '\nxywh=1,2,3,4'` the engine
backtracked superlinearly: at `n=16000` the issue reporter measured
parse times around 485 ms. The coordinate fields were also parsed with
`parseFloat`, which silently truncated `'10abc'` to `10`, so values
like `xywh=pixel:10abc,20def,30ghi,40jkl` were accepted as a valid
rectangle even in `strict: true` mode.

* `FragmentSelector.ts` now uses a single anchored, numeric-only
  expression (`^xywh=(?:(pixel|percent):)?N,N,N,N$`) where `N` allows
  integers, decimals, scientific notation, and a leading minus. URI-
  style inputs (`https://.../image.jpg#xywh=...`) are normalized via a
  small `stripHash` helper before matching, so the regex itself never
  scans across arbitrary URI prefixes.
* Coordinate fields are now converted with `Number`, which rejects
  non-numeric suffixes (`10abc` → `NaN`); since the regex no longer
  matches such tokens, the parser throws `Not a MediaFragment` instead
  of returning a half-truncated rectangle.

The existing five tests still pass unchanged. Four new tests cover:

* malformed coordinate rejection (`10abc,...`),
* bounded parse time on the reporter's adversarial payload at n=16000,
* decimal coordinates,
* URI fragments with `#xywh=`.

On my machine the reporter's largest payload (n=64000, ~320 KB) now
parses in well under a millisecond.