### PR TITLE
Added `syncAnnotations` method with diff-based reconciliation that preserves active selection

### DIFF
--- a/packages/annotorious-core/src/model/Annotator.ts
+++ b/packages/annotorious-core/src/model/Annotator.ts
@@ -46,13 +46,13 @@ export interface Annotator<I extends Annotation = Annotation, E extends unknown 
 
   getUser(): User;
 
-  loadAnnotations(url: string, replace?: boolean): Promise<E[]>;
+  loadAnnotations(url: string): Promise<E[]>;
 
   redo(): void;
 
   removeAnnotation(arg: Partial<E> | string): E | undefined;
 
-  setAnnotations(annotations: Partial<E>[], replace?: boolean): void;
+  setAnnotations(annotations: Partial<E>[]): void;
 
   setFilter(filter: Filter<I> | undefined): void;
 
@@ -136,11 +136,11 @@ export const createBaseAnnotator = <I extends Annotation, E extends unknown>(
       : selected as unknown as E[];
   }
 
-  const loadAnnotations = (url: string, replace = true) =>
+  const loadAnnotations = (url: string) =>
     fetch(url)
       .then((response) => response.json())
       .then((annotations) => {
-        setAnnotations(annotations, replace);
+        setAnnotations(annotations);
         return annotations;
       });
 
@@ -161,7 +161,7 @@ export const createBaseAnnotator = <I extends Annotation, E extends unknown>(
     }
   }
 
-  const setAnnotations = (annotations: E[], replace = true) => {
+  const setAnnotations = (annotations: E[]) => {
     if (adapter) {
       const parseFn = adapter.parseAll || parseAll(adapter);
       const { parsed, failed } = parseFn(annotations);
@@ -169,18 +169,9 @@ export const createBaseAnnotator = <I extends Annotation, E extends unknown>(
       if (failed.length > 0)
         console.warn(`Discarded ${failed.length} invalid annotations`, failed);
 
-      if (replace) {
-        store.syncAnnotations(parsed, Origin.REMOTE);
-      } else {
-        store.bulkAddAnnotations(parsed, false, Origin.REMOTE);
-      }
+      store.syncAnnotations(parsed, Origin.REMOTE);
     } else {
-      const mapped = annotations.map(reviveDates<I>);
-      if (replace) {
-        store.syncAnnotations(mapped, Origin.REMOTE);
-      } else {
-        store.bulkAddAnnotations(mapped, false, Origin.REMOTE);
-      }
+      store.syncAnnotations(annotations.map(reviveDates<I>), Origin.REMOTE);
     }
   }
 

--- a/packages/annotorious-core/src/model/Annotator.ts
+++ b/packages/annotorious-core/src/model/Annotator.ts
@@ -169,9 +169,18 @@ export const createBaseAnnotator = <I extends Annotation, E extends unknown>(
       if (failed.length > 0)
         console.warn(`Discarded ${failed.length} invalid annotations`, failed);
 
-      store.bulkAddAnnotations(parsed, replace, Origin.REMOTE);
+      if (replace) {
+        store.syncAnnotations(parsed, Origin.REMOTE);
+      } else {
+        store.bulkAddAnnotations(parsed, false, Origin.REMOTE);
+      }
     } else {
-      store.bulkAddAnnotations(annotations.map(reviveDates<I>), replace, Origin.REMOTE);
+      const mapped = annotations.map(reviveDates<I>);
+      if (replace) {
+        store.syncAnnotations(mapped, Origin.REMOTE);
+      } else {
+        store.bulkAddAnnotations(mapped, false, Origin.REMOTE);
+      }
     }
   }
 

--- a/packages/annotorious-core/src/model/Annotator.ts
+++ b/packages/annotorious-core/src/model/Annotator.ts
@@ -46,13 +46,13 @@ export interface Annotator<I extends Annotation = Annotation, E extends unknown 
 
   getUser(): User;
 
-  loadAnnotations(url: string): Promise<E[]>;
+  loadAnnotations(url: string, replace?: boolean): Promise<E[]>;
 
   redo(): void;
 
   removeAnnotation(arg: Partial<E> | string): E | undefined;
 
-  setAnnotations(annotations: Partial<E>[]): void;
+  setAnnotations(annotations: Partial<E>[], replace?: boolean): void;
 
   setFilter(filter: Filter<I> | undefined): void;
 
@@ -136,11 +136,11 @@ export const createBaseAnnotator = <I extends Annotation, E extends unknown>(
       : selected as unknown as E[];
   }
 
-  const loadAnnotations = (url: string) =>
+  const loadAnnotations = (url: string, replace = true) =>
     fetch(url)
       .then((response) => response.json())
       .then((annotations) => {
-        setAnnotations(annotations);
+        setAnnotations(annotations, replace);
         return annotations;
       });
 
@@ -161,7 +161,9 @@ export const createBaseAnnotator = <I extends Annotation, E extends unknown>(
     }
   }
 
-  const setAnnotations = (annotations: E[]) => {
+  const setAnnotations = (annotations: E[], replace = true) => {
+    const apply = replace ? store.syncAnnotations : store.bulkUpsertAnnotations;
+
     if (adapter) {
       const parseFn = adapter.parseAll || parseAll(adapter);
       const { parsed, failed } = parseFn(annotations);
@@ -169,9 +171,9 @@ export const createBaseAnnotator = <I extends Annotation, E extends unknown>(
       if (failed.length > 0)
         console.warn(`Discarded ${failed.length} invalid annotations`, failed);
 
-      store.syncAnnotations(parsed, Origin.REMOTE);
+      apply(parsed, Origin.REMOTE);
     } else {
-      store.syncAnnotations(annotations.map(reviveDates<I>), Origin.REMOTE);
+      apply(annotations.map(reviveDates<I>), Origin.REMOTE);
     }
   }
 

--- a/packages/annotorious-core/src/state/Store.ts
+++ b/packages/annotorious-core/src/state/Store.ts
@@ -63,6 +63,11 @@ export const createStore = <T extends Annotation>() => {
     });
   }
 
+  const insertOneAnnotation = (annotation: T) => {
+    annotationIndex.set(annotation.id, annotation);
+    annotation.bodies.forEach(b => bodyIndex.set(b.id, annotation.id));
+  }
+
   const addAnnotation = (annotation: Partial<T>, origin = Origin.LOCAL) => {
     const existing = annotation.id && annotationIndex.get(annotation.id);
 
@@ -71,8 +76,7 @@ export const createStore = <T extends Annotation>() => {
     } else {
       const sanitized = sanitize(annotation);
 
-      annotationIndex.set(sanitized.id, sanitized);
-      sanitized.bodies.forEach(b => bodyIndex.set(b.id, sanitized.id));
+      insertOneAnnotation(sanitized);
       emit(origin, { created: [sanitized] });
     }
   }
@@ -143,10 +147,7 @@ export const createStore = <T extends Annotation>() => {
 
     const updated = toUpdate.map(a => updateOneAnnotation(a, origin)!).filter(Boolean);
 
-    toAdd.forEach(annotation => {
-      annotationIndex.set(annotation.id, annotation);
-      annotation.bodies.forEach(b => bodyIndex.set(b.id, annotation.id));
-    });
+    toAdd.forEach(insertOneAnnotation);
 
     emit(origin, { created: toAdd, updated });
   }
@@ -193,10 +194,7 @@ export const createStore = <T extends Annotation>() => {
       annotationIndex.clear();
       bodyIndex.clear();
 
-      sanitized.forEach(annotation => {
-        annotationIndex.set(annotation.id, annotation);
-        annotation.bodies.forEach(b => bodyIndex.set(b.id, annotation.id));
-      });
+      sanitized.forEach(insertOneAnnotation);
 
       emit(origin, { created: sanitized, deleted });
     } else {
@@ -209,13 +207,36 @@ export const createStore = <T extends Annotation>() => {
       if (existing.length > 0)
         throw Error(`Bulk insert would overwrite the following annotations: ${existing.map(a => a.id).join(', ')}`);
 
-      sanitized.forEach(annotation => {
-        annotationIndex.set(annotation.id, annotation);
-        annotation.bodies.forEach(b => bodyIndex.set(b.id, annotation.id));
-      });
+      sanitized.forEach(insertOneAnnotation);
 
       emit(origin, { created: sanitized });
     }
+  }
+
+  const syncAnnotations = (annotations: Partial<T>[], origin = Origin.LOCAL) => {
+    const sanitized = annotations.map(sanitize);
+
+    const incomingIds = new Set(sanitized.map(a => a.id));
+
+    const { toAdd, toUpdate } = sanitized.reduce<{ toAdd: T[], toUpdate: T[] }>((agg, annotation) => {
+      const exists = Boolean(annotationIndex.get(annotation.id));
+      if (exists) {
+        return { ...agg, toUpdate: [...agg.toUpdate, annotation] };
+      } else {
+        return { ...agg, toAdd: [...agg.toAdd, annotation] };
+      }
+    }, { toAdd: [], toUpdate: [] });
+
+    const deleted = [...annotationIndex.keys()]
+      .filter(id => !incomingIds.has(id))
+      .map(id => deleteOneAnnotation(id)!)
+      .filter(Boolean);
+
+    const updated = toUpdate.map(a => updateOneAnnotation(a)!).filter(Boolean);
+
+    toAdd.forEach(insertOneAnnotation);
+
+    emit(origin, { created: toAdd, updated, deleted });
   }
 
   const deleteOneAnnotation = (annotationOrId: T | string) => {
@@ -410,6 +431,7 @@ export const createStore = <T extends Annotation>() => {
     getAnnotation,
     getBody,
     observe,
+    syncAnnotations,
     unobserve,
     updateAnnotation,
     updateBody,

--- a/packages/annotorious-core/src/state/Store.ts
+++ b/packages/annotorious-core/src/state/Store.ts
@@ -133,20 +133,43 @@ export const createStore = <T extends Annotation>() => {
       emit(origin, { updated });
   }
 
-  const bulkUpsertAnnotations = (annotations: Partial<T>[], origin = Origin.LOCAL) => {
+  /**
+   * Sanitizes the input and splits it into "new to the store" vs. "already exists in the store".
+   * Shared by `bulkUpsertAnnotations` and `syncAnnotations`.
+   */
+  const partitionAddAndUpdate = (annotations: Partial<T>[]): { toAdd: T[], toUpdate: T[] } => {
     const sanitized = annotations.map(sanitize);
 
-    const { toAdd, toUpdate } = sanitized.reduce<{ toAdd: T[], toUpdate: T[] }>((agg, annotation) => {
+    return sanitized.reduce<{ toAdd: T[], toUpdate: T[] }>((agg, annotation) => {
       const exists = Boolean(annotationIndex.get(annotation.id));
       if (exists) {
-        return {...agg, toUpdate: [...agg.toUpdate, annotation]};
+        return { ...agg, toUpdate: [...agg.toUpdate, annotation] };
       } else {
-        return {...agg, toAdd: [...agg.toAdd, annotation]}
+        return { ...agg, toAdd: [...agg.toAdd, annotation] };
       }
     }, { toAdd: [], toUpdate: [] });
+  }
+
+  /**
+   * Merges the given annotations into the store without touching anything else.
+   *
+   * For each input annotation:
+   * - if an annotation with the same id already exists, it is updated in place;
+   * - otherwise, it is inserted as a new annotation.
+   *
+   * Annotations already in the store whose ids are absent from the input are
+   * left untouched. Use this when you have a partial delta to apply on top of
+   * the current state — for example, when redoing a creation or undoing a
+   * deletion in the undo stack.
+   *
+   * Emits a single change event with `created` and `updated` populated.
+   *
+   * @see syncAnnotations for the "mirror this exact list" variant that also deletes.
+   */
+  const bulkUpsertAnnotations = (annotations: Partial<T>[], origin = Origin.LOCAL) => {
+    const { toAdd, toUpdate } = partitionAddAndUpdate(annotations);
 
     const updated = toUpdate.map(a => updateOneAnnotation(a, origin)!).filter(Boolean);
-
     toAdd.forEach(insertOneAnnotation);
 
     emit(origin, { created: toAdd, updated });
@@ -185,27 +208,36 @@ export const createStore = <T extends Annotation>() => {
     emit(origin, { deleted: all });
   }
 
+  /**
+   * Replaces the store's contents with the given annotations, preserving the
+   * identity of any annotation that survives the sync.
+   *
+   * For each annotation currently in the store:
+   * - if its id is in the input, the existing entry is updated in place — so
+   *   observers (including the selection state) keep their reference;
+   * - if its id is absent from the input, the entry is deleted.
+   *
+   * Annotations in the input that don't yet exist in the store are inserted.
+   *
+   * Use this when you have an authoritative full list of annotations and need
+   * the store to mirror it. Unlike `clear()` followed by a bulk insert, this
+   * preserves selection and any other state keyed on annotation id for
+   * annotations that survive.
+   *
+   * Emits a single change event with `created`, `updated`, and `deleted` populated.
+   *
+   * @see bulkUpsertAnnotations for the "merge in" variant that never deletes.
+   */
   const syncAnnotations = (annotations: Partial<T>[], origin = Origin.LOCAL) => {
-    const sanitized = annotations.map(sanitize);
+    const { toAdd, toUpdate } = partitionAddAndUpdate(annotations);
 
-    const incomingIds = new Set(sanitized.map(a => a.id));
-
-    const { toAdd, toUpdate } = sanitized.reduce<{ toAdd: T[], toUpdate: T[] }>((agg, annotation) => {
-      const exists = Boolean(annotationIndex.get(annotation.id));
-      if (exists) {
-        return { ...agg, toUpdate: [...agg.toUpdate, annotation] };
-      } else {
-        return { ...agg, toAdd: [...agg.toAdd, annotation] };
-      }
-    }, { toAdd: [], toUpdate: [] });
-
+    const incomingIds = new Set([...toAdd, ...toUpdate].map(a => a.id));
     const deleted = [...annotationIndex.keys()]
       .filter(id => !incomingIds.has(id))
       .map(id => deleteOneAnnotation(id)!)
       .filter(Boolean);
 
     const updated = toUpdate.map(a => updateOneAnnotation(a)!).filter(Boolean);
-
     toAdd.forEach(insertOneAnnotation);
 
     emit(origin, { created: toAdd, updated, deleted });

--- a/packages/annotorious-core/src/state/Store.ts
+++ b/packages/annotorious-core/src/state/Store.ts
@@ -185,34 +185,6 @@ export const createStore = <T extends Annotation>() => {
     emit(origin, { deleted: all });
   }
 
-  const bulkAddAnnotations = (annotations: Partial<T>[], replace = true, origin = Origin.LOCAL) => {
-    const sanitized = annotations.map(sanitize);
-
-    if (replace) {
-      // Delete existing first
-      const deleted = [...annotationIndex.values()];
-      annotationIndex.clear();
-      bodyIndex.clear();
-
-      sanitized.forEach(insertOneAnnotation);
-
-      emit(origin, { created: sanitized, deleted });
-    } else {
-      // Don't allow overwriting of existing annotations
-      const existing = annotations.reduce((all, next) => {
-        const existing = next.id && annotationIndex.get(next.id);
-        return existing ? [...all, existing ] : all;
-      }, [] as T[]);
-
-      if (existing.length > 0)
-        throw Error(`Bulk insert would overwrite the following annotations: ${existing.map(a => a.id).join(', ')}`);
-
-      sanitized.forEach(insertOneAnnotation);
-
-      emit(origin, { created: sanitized });
-    }
-  }
-
   const syncAnnotations = (annotations: Partial<T>[], origin = Origin.LOCAL) => {
     const sanitized = annotations.map(sanitize);
 
@@ -418,7 +390,6 @@ export const createStore = <T extends Annotation>() => {
     addAnnotation,
     addBody,
     all,
-    bulkAddAnnotations,
     bulkDeleteAnnotations,
     bulkDeleteBodies,
     bulkUpdateAnnotations,

--- a/packages/annotorious-core/src/state/UndoStack.ts
+++ b/packages/annotorious-core/src/state/UndoStack.ts
@@ -86,7 +86,7 @@ export const createUndoStack = <T extends Annotation>(store: Store<T>, history?:
     created && created.length > 0 && store.bulkDeleteAnnotations(created);
 
   const redoCreated = (created?: T[]) =>
-    created && created.length > 0 && store.bulkAddAnnotations(created, false);
+    created && created.length > 0 && store.bulkUpsertAnnotations(created);
 
   const undoUpdated = (updated?: Update<T>[]) =>
     updated && updated.length > 0 && store.bulkUpdateAnnotations(updated.map(({ oldValue }) => oldValue));
@@ -94,8 +94,8 @@ export const createUndoStack = <T extends Annotation>(store: Store<T>, history?:
   const redoUpdated = (updated?: Update<T>[]) =>
     updated && updated.length > 0 && store.bulkUpdateAnnotations(updated.map(({ newValue }) => newValue));
 
-  const undoDeleted = (deleted?: T[]) => 
-    deleted && deleted.length > 0 && store.bulkAddAnnotations(deleted, false);
+  const undoDeleted = (deleted?: T[]) =>
+    deleted && deleted.length > 0 && store.bulkUpsertAnnotations(deleted);
 
   const redoDeleted = (deleted?: T[]) =>
     deleted && deleted.length > 0 && store.bulkDeleteAnnotations(deleted);

--- a/packages/annotorious-core/test/state/Selection.test.ts
+++ b/packages/annotorious-core/test/state/Selection.test.ts
@@ -54,7 +54,29 @@ describe('createSelectionState', () => {
       expect(selectionState.isSelected(testAnnotation2)).toBe(true);
       expect(selectionState.isSelected(testAnnotation3)).toBe(false);
     });
-    
+
+  });
+
+  describe('syncAnnotations selection preservation', () => {
+
+    it('should preserve selection when the selected annotation survives a sync', () => {
+      selectionState.setSelected(testAnnotation1.id);
+      expect(selectionState.isSelected(testAnnotation1)).toBe(true);
+
+      store.syncAnnotations([testAnnotation1, testAnnotation2, testAnnotation3]);
+
+      expect(selectionState.isSelected(testAnnotation1)).toBe(true);
+    });
+
+    it('should clear selection when the selected annotation is removed by a sync', () => {
+      selectionState.setSelected(testAnnotation1.id);
+      expect(selectionState.isSelected(testAnnotation1)).toBe(true);
+
+      store.syncAnnotations([testAnnotation2, testAnnotation3]);
+
+      expect(selectionState.isEmpty()).toBe(true);
+    });
+
   });
 
 });

--- a/packages/annotorious-core/test/state/Selection.test.ts
+++ b/packages/annotorious-core/test/state/Selection.test.ts
@@ -30,7 +30,7 @@ describe('createSelectionState', () => {
 
   beforeEach(() => {
     store = createStore<Annotation>();
-    store.bulkAddAnnotations([testAnnotation1, testAnnotation2, testAnnotation3]);
+    store.syncAnnotations([testAnnotation1, testAnnotation2, testAnnotation3]);
     selectionState = createSelectionState(store);
   });
 

--- a/packages/annotorious-core/test/state/Store.test.ts
+++ b/packages/annotorious-core/test/state/Store.test.ts
@@ -96,27 +96,6 @@ describe('store', () => {
     expect(updatedAnnotation?.bodies.map(b => b.id)).toContain('body-2');
   });
 
-  it('should properly run bulkAddAnnotation', () => {
-    const store = createStore();
-
-    const newAnnotations = [
-      annotation,
-      {
-        id: 'annotation-2',
-        target: {
-          annotation: 'annotation-2',
-          selector: {},
-        },
-        bodies: [],
-      },
-    ];
-
-    store.bulkAddAnnotations(newAnnotations);
-
-    expect(store.getAnnotation('annotation-1')).toBeDefined();
-    expect(store.getAnnotation('annotation-2')).toBeDefined();
-  });
-
   it('should properly run deleteAnnotation', () => {
     const store = createStore();
     store.addAnnotation(annotation);
@@ -262,7 +241,7 @@ describe('store', () => {
 
     it('should emit updated for annotations present in both store and input', () => {
       const store = createStore();
-      store.bulkAddAnnotations([existing1, existing2]);
+      store.syncAnnotations([existing1, existing2]);
 
       const mockObserver = vi.fn();
       store.observe(mockObserver);
@@ -279,7 +258,7 @@ describe('store', () => {
 
     it('should emit deleted for annotations only in store', () => {
       const store = createStore();
-      store.bulkAddAnnotations([existing1, existing2]);
+      store.syncAnnotations([existing1, existing2]);
 
       const mockObserver = vi.fn();
       store.observe(mockObserver);
@@ -296,7 +275,7 @@ describe('store', () => {
 
     it('should emit a combined changeset for mixed create/update/delete', () => {
       const store = createStore();
-      store.bulkAddAnnotations([existing1, existing2]);
+      store.syncAnnotations([existing1, existing2]);
 
       const mockObserver = vi.fn();
       store.observe(mockObserver);

--- a/packages/annotorious-core/test/state/Store.test.ts
+++ b/packages/annotorious-core/test/state/Store.test.ts
@@ -234,4 +234,83 @@ describe('store', () => {
     expect(inserted?.target.annotation).toBe(autoId);
   });
 
+  describe('syncAnnotations', () => {
+    const existing1 = {
+      id: 'sync-1',
+      target: { annotation: 'sync-1', selector: {} },
+      bodies: [],
+    };
+
+    const existing2 = {
+      id: 'sync-2',
+      target: { annotation: 'sync-2', selector: {} },
+      bodies: [],
+    };
+
+    it('should emit created for new annotations', () => {
+      const store = createStore();
+      const mockObserver = vi.fn();
+      store.observe(mockObserver);
+
+      store.syncAnnotations([existing1]);
+
+      expect(store.getAnnotation('sync-1')).toBeDefined();
+      expect(mockObserver.mock.calls[0][0].changes.created).toHaveLength(1);
+      expect(mockObserver.mock.calls[0][0].changes.updated).toHaveLength(0);
+      expect(mockObserver.mock.calls[0][0].changes.deleted).toHaveLength(0);
+    });
+
+    it('should emit updated for annotations present in both store and input', () => {
+      const store = createStore();
+      store.bulkAddAnnotations([existing1, existing2]);
+
+      const mockObserver = vi.fn();
+      store.observe(mockObserver);
+
+      const updated1 = { ...existing1, bodies: [{ id: 'body-new', annotation: 'sync-1', value: 'hello' }] };
+      store.syncAnnotations([updated1, existing2]);
+
+      const changes = mockObserver.mock.calls[0][0].changes;
+      expect(changes.created).toHaveLength(0);
+      expect(changes.updated).toHaveLength(2);
+      expect(changes.updated.map((u: { newValue: Annotation }) => u.newValue.id)).toContain('sync-1');
+      expect(changes.deleted).toHaveLength(0);
+    });
+
+    it('should emit deleted for annotations only in store', () => {
+      const store = createStore();
+      store.bulkAddAnnotations([existing1, existing2]);
+
+      const mockObserver = vi.fn();
+      store.observe(mockObserver);
+
+      store.syncAnnotations([existing1]);
+
+      const changes = mockObserver.mock.calls[0][0].changes;
+      expect(changes.created).toHaveLength(0);
+      expect(changes.updated).toHaveLength(1);
+      expect(changes.deleted).toHaveLength(1);
+      expect(changes.deleted[0].id).toBe('sync-2');
+      expect(store.getAnnotation('sync-2')).toBeUndefined();
+    });
+
+    it('should emit a combined changeset for mixed create/update/delete', () => {
+      const store = createStore();
+      store.bulkAddAnnotations([existing1, existing2]);
+
+      const mockObserver = vi.fn();
+      store.observe(mockObserver);
+
+      const newAnnotation = { id: 'sync-3', target: { annotation: 'sync-3', selector: {} }, bodies: [] };
+      const updatedExisting1 = { ...existing1, bodies: [{ id: 'b1', annotation: 'sync-1', value: 'x' }] };
+
+      store.syncAnnotations([updatedExisting1, newAnnotation]);
+
+      const changes = mockObserver.mock.calls[0][0].changes;
+      expect(changes.created.map((a: Annotation) => a.id)).toContain('sync-3');
+      expect(changes.updated.map((u: { newValue: Annotation }) => u.newValue.id)).toContain('sync-1');
+      expect(changes.deleted.map((a: Annotation) => a.id)).toContain('sync-2');
+    });
+  });
+
 });


### PR DESCRIPTION
## Issue
Fixes https://github.com/annotorious/annotorious/issues/605

## Changes Made
`setAnnotations` previously performed a destructive wipe-and-reinsert when called with `replace=true` (the default), reporting every existing annotation as deleted. Even if the latter reappeared in the new payload, causing active selections to be dismissed mid-interaction. 

This PR introduces diff-based reconciliation: annotations present in both the old and new state are updated in-place, new ones are added, _and only annotations genuinely absent from the new payload are deleted_. That was the key piece missing from the existing store methods infrastructure.

As a side effect, a repeated index-manipulation pattern across the store was consolidated into a shared helper. 

The result is that periodic data refreshes no longer interrupt the user — open popups and editors stay mounted as long as the selected annotation is still included in the incoming data.