### PR TITLE
Make OpenSeadragon polygon simplification tolerance configurable

### DIFF
--- a/packages/annotorious-openseadragon/src/Annotorious.ts
+++ b/packages/annotorious-openseadragon/src/Annotorious.ts
@@ -115,7 +115,8 @@ export const createOSDAnnotator = <I extends Annotation = ImageAnnotation, E ext
       state, 
       viewer, 
       style: opts.style,
-      filter: undefined
+      filter: undefined,
+      polygonSimplificationTolerance: opts.polygonSimplificationTolerance
     }
   });
 

--- a/packages/annotorious-openseadragon/src/AnnotoriousOSDOpts.ts
+++ b/packages/annotorious-openseadragon/src/AnnotoriousOSDOpts.ts
@@ -5,4 +5,8 @@ export interface AnnotoriousOSDOpts<I extends Annotation = ImageAnnotation, E ex
   // Enable SHIFT/CTRL/CMD + multi-selection
   multiSelect?: boolean;
 
+  // Tolerance for polygon/multipolygon simplification in the WebGL display layer.
+  // Set to 0 to preserve the full geometry.
+  polygonSimplificationTolerance?: number;
+
 }

--- a/packages/annotorious-openseadragon/src/annotation/pixi/PixiLayer.svelte
+++ b/packages/annotorious-openseadragon/src/annotation/pixi/PixiLayer.svelte
@@ -16,6 +16,7 @@
   export let style: DrawingStyleExpression<ImageAnnotation> | undefined;
   export let viewer: OpenSeadragon.Viewer;
   export let visible = true;
+  export let polygonSimplificationTolerance = 1;
 
   const { store, hover, selection, viewport } = state;
 
@@ -156,7 +157,7 @@
       const { selector }  = a.target;
 
       if (selector.type === ShapeType.POLYGON) {
-        const shape = simplifyPolygon(selector as Polygon);
+        const shape = simplifyPolygon(selector as Polygon, polygonSimplificationTolerance);
         return {
           ...a,
           target: {
@@ -167,7 +168,7 @@
           }
         }
       } else if (selector.type === ShapeType.MULTIPOLYGON) {
-        const shape = simplifyMultiPolygon(selector as MultiPolygon);
+        const shape = simplifyMultiPolygon(selector as MultiPolygon, polygonSimplificationTolerance);
         return {
           ...a,
           target: {

--- a/packages/annotorious/test/model/core/simplificationTolerance.test.ts
+++ b/packages/annotorious/test/model/core/simplificationTolerance.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { ShapeType, simplifyMultiPolygon, simplifyPolygon } from '../../../src/model/core';
+import type { MultiPolygon, Polygon } from '../../../src/model/core';
+
+const detailedPoints: [number, number][] = [
+  [0, 0],
+  [1, 0.25],
+  [2, -0.25],
+  [3, 0.25],
+  [4, 0],
+  [4, 4],
+  [3, 4.25],
+  [2, 3.75],
+  [1, 4.25],
+  [0, 4],
+  [0, 0]
+];
+
+const bounds = {
+  minX: 0,
+  minY: -0.25,
+  maxX: 4,
+  maxY: 4.25
+};
+
+describe('polygon simplification tolerance', () => {
+  it('preserves polygon points when tolerance is zero', () => {
+    const polygon: Polygon = {
+      type: ShapeType.POLYGON,
+      geometry: {
+        bounds,
+        points: detailedPoints
+      }
+    };
+
+    expect(simplifyPolygon(polygon).geometry.points.length)
+      .toBeLessThan(detailedPoints.length);
+
+    expect(simplifyPolygon(polygon, 0).geometry.points)
+      .toEqual(detailedPoints);
+  });
+
+  it('preserves multipolygon ring points when tolerance is zero', () => {
+    const multiPolygon: MultiPolygon = {
+      type: ShapeType.MULTIPOLYGON,
+      geometry: {
+        bounds,
+        polygons: [{
+          bounds,
+          rings: [{
+            points: detailedPoints
+          }]
+        }]
+      }
+    };
+
+    expect(simplifyMultiPolygon(multiPolygon).geometry.polygons[0].rings[0].points.length)
+      .toBeLessThan(detailedPoints.length);
+
+    expect(simplifyMultiPolygon(multiPolygon, 0).geometry.polygons[0].rings[0].points)
+      .toEqual(detailedPoints);
+  });
+});


### PR DESCRIPTION
Closes #595.

## Summary

- add a `polygonSimplificationTolerance` OpenSeadragon option for the Pixi display layer
- keep the existing default tolerance of `1` so current rendering behavior stays unchanged by default
- allow callers to set the tolerance to `0` when they need full polygon/multipolygon geometry preserved
- add regression coverage for polygon and multipolygon simplification tolerance

## Validation

- `npm test --workspace @annotorious/annotorious -- simplificationTolerance.test.ts`
- `npm test --workspace @annotorious/annotorious`
- `npm run build --workspace @annotorious/openseadragon`
- `npm test`
- `npm run build`