### PR TITLE
Fix coordinate mapping css transformed ancestors

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "BSD-3-Clause",
   "scripts": {
     "build": "npm run build --workspaces",
+    "playground:osd": "npm run start --workspace @annotorious/react -- --open /test/openseadragon-coordinate-mapping/index.html",
     "test": "npm run test --workspaces"
   },
   "workspaces": [

--- a/packages/annotorious-openseadragon/src/annotation/pixi/PixiLayer.svelte
+++ b/packages/annotorious-openseadragon/src/annotation/pixi/PixiLayer.svelte
@@ -7,6 +7,7 @@
   import type { Filter, ImageAnnotation, ImageAnnotatorState, MultiPolygon, Polygon } from '@annotorious/annotorious';
   import type { PixiLayerClickEvent } from './PixiLayerClickEvent';
   import { createStage } from './stageRenderer';
+  import { getViewerPoint } from '../../utils';
 
   import './PixiLayer.css';
 
@@ -36,18 +37,6 @@
 
   $: stage?.setVisible(visible);
 
-  // Convert screen coordinates to the viewer's untransformed local coordinate
-  // system. OSD's viewport APIs expect these layout pixels, while PointerEvent
-  // offsets are inconsistent when an HTML ancestor is CSS-transformed.
-  const getViewerPoint = (evt: PointerEvent): OpenSeadragon.Point => {
-    const { left, top, width, height } = viewer.element.getBoundingClientRect();
-
-    return new OpenSeadragon.Point(
-      (evt.clientX - left) * (viewer.element.clientWidth / width),
-      (evt.clientY - top) * (viewer.element.clientHeight / height)
-    );
-  }
-
   const getImageXY = (xy: OpenSeadragon.Point): OpenSeadragon.Point => {
     const {x, y} = viewer.viewport.pointFromPixel(xy);
     return viewer.viewport.viewportToImageCoordinates(x, y);
@@ -56,12 +45,12 @@
   const getHitTolerance= () => HIT_TOLERANCE_BASE / stage.getScale();
 
   const onCanvasPress = (evt: OpenSeadragon.CanvasPressEvent) => {
-    const { x, y } = getViewerPoint(evt.originalEvent as PointerEvent);
+    const { x, y } = getViewerPoint(viewer, evt.originalEvent as PointerEvent);
     lastPress = { x, y };
   }
 
   const onPointerMove = (canvas: HTMLCanvasElement) => (evt: PointerEvent) => {
-    const {x, y} = getImageXY(getViewerPoint(evt));
+    const {x, y} = getImageXY(getViewerPoint(viewer, evt));
     const buffer = getHitTolerance();
     const hit = store.getAt(x, y, filter, buffer);
     if (hit) {
@@ -86,14 +75,14 @@
 
     const originalEvent = evt.originalEvent as PointerEvent;
 
-    const { x, y } = getViewerPoint(originalEvent);
+    const { x, y } = getViewerPoint(viewer, originalEvent);
     const dx = x - lastPress.x;
     const dy = y - lastPress.y;
 
     const dist = Math.sqrt(dx * dx + dy * dy);
 
     if (dist < 5) {
-      const {x, y} = getImageXY(getViewerPoint(originalEvent));
+      const {x, y} = getImageXY(getViewerPoint(viewer, originalEvent));
       const buffer = getHitTolerance();
       const annotation = store.getAt(x, y, filter, buffer);
 

--- a/packages/annotorious-openseadragon/src/annotation/pixi/PixiLayer.svelte
+++ b/packages/annotorious-openseadragon/src/annotation/pixi/PixiLayer.svelte
@@ -36,22 +36,32 @@
 
   $: stage?.setVisible(visible);
 
-  // Helper
+  // Convert screen coordinates to the viewer's untransformed local coordinate
+  // system. OSD's viewport APIs expect these layout pixels, while PointerEvent
+  // offsets are inconsistent when an HTML ancestor is CSS-transformed.
+  const getViewerPoint = (evt: PointerEvent): OpenSeadragon.Point => {
+    const { left, top, width, height } = viewer.element.getBoundingClientRect();
+
+    return new OpenSeadragon.Point(
+      (evt.clientX - left) * (viewer.element.clientWidth / width),
+      (evt.clientY - top) * (viewer.element.clientHeight / height)
+    );
+  }
+
   const getImageXY = (xy: OpenSeadragon.Point): OpenSeadragon.Point => {
-    const offsetXY = new OpenSeadragon.Point(xy.x, xy.y);
-    const {x, y} = viewer.viewport.pointFromPixel(offsetXY);
+    const {x, y} = viewer.viewport.pointFromPixel(xy);
     return viewer.viewport.viewportToImageCoordinates(x, y);
   }
 
   const getHitTolerance= () => HIT_TOLERANCE_BASE / stage.getScale();
 
   const onCanvasPress = (evt: OpenSeadragon.CanvasPressEvent) => {
-    const { x, y } = evt.position;
+    const { x, y } = getViewerPoint(evt.originalEvent as PointerEvent);
     lastPress = { x, y };
   }
 
   const onPointerMove = (canvas: HTMLCanvasElement) => (evt: PointerEvent) => {
-    const {x, y} = getImageXY(new OpenSeadragon.Point(evt.offsetX, evt.offsetY));
+    const {x, y} = getImageXY(getViewerPoint(evt));
     const buffer = getHitTolerance();
     const hit = store.getAt(x, y, filter, buffer);
     if (hit) {
@@ -76,14 +86,14 @@
 
     const originalEvent = evt.originalEvent as PointerEvent;
 
-    const { x, y } = evt.position;
+    const { x, y } = getViewerPoint(originalEvent);
     const dx = x - lastPress.x;
     const dy = y - lastPress.y;
 
     const dist = Math.sqrt(dx * dx + dy * dy);
 
     if (dist < 5) {
-      const {x, y} = getImageXY(evt.position);
+      const {x, y} = getImageXY(getViewerPoint(originalEvent));
       const buffer = getHitTolerance();
       const annotation = store.getAt(x, y, filter, buffer);
 

--- a/packages/annotorious-openseadragon/src/annotation/svg/drawing/SVGDrawingLayer.svelte
+++ b/packages/annotorious-openseadragon/src/annotation/svg/drawing/SVGDrawingLayer.svelte
@@ -6,7 +6,7 @@
   import { EditorMount } from '@annotorious/annotorious/src'; // Import Svelte components from source
   import { getEditor as _getEditor, getTool, isImageAnnotation, isTouch, listDrawingTools } from '@annotorious/annotorious';
   import type { ImageAnnotation, Shape, ImageAnnotatorState, DrawingMode } from '@annotorious/annotorious';
-  import { updateSelection } from '../../../utils';
+  import { getViewerPoint, updateSelection } from '../../../utils';
   import OSDLayer from '../OSDLayer.svelte';
   import OSDToolMount from './OSDToolMount.svelte';
 
@@ -97,18 +97,6 @@
     }
   }
 
-  // Convert a screen pointer position into the viewer's untransformed local
-  // coordinate system. This keeps OSD viewport mapping correct when the viewer
-  // sits inside a CSS-transformed ancestor.
-  const getViewerPoint = (evt: PointerEvent): OpenSeadragon.Point => {
-    const { left, top, width, height } = viewer.element.getBoundingClientRect();
-
-    return new OpenSeadragon.Point(
-      (evt.clientX - left) * (viewer.element.clientWidth / width),
-      (evt.clientY - top) * (viewer.element.clientHeight / height)
-    );
-  }
-
   // Coordinate transform, viewer-local pixels to OSD image coordinates
   const toolTransform = (offsetX: number, offsetY: number): [number, number] => {
     const {x, y} = viewer.viewport.viewerElementToImageCoordinates(new OpenSeadragon.Point(offsetX, offsetY));
@@ -116,7 +104,7 @@
   }
 
   const eventToImage = (evt: PointerEvent): [number, number] => {
-    const { x, y } = getViewerPoint(evt);
+    const { x, y } = getViewerPoint(viewer, evt);
     return toolTransform(x, y);
   }
 
@@ -158,7 +146,7 @@
   }
 
   const onPointerMove = (evt: PointerEvent) => {
-    const pt = viewer.viewport.pointFromPixel(getViewerPoint(evt));
+    const pt = viewer.viewport.pointFromPixel(getViewerPoint(viewer, evt));
     const { x, y } = viewer.viewport.viewportToImageCoordinates(pt.x, pt.y);
 
     const buffer = getHitTolerance();
@@ -222,7 +210,7 @@
     const onPointerMove = (evt: PointerEvent) => {
       if (($selection as Selection).selected.length === 0) return;
 
-      const pt = viewer.viewport.pointFromPixel(getViewerPoint(evt));
+      const pt = viewer.viewport.pointFromPixel(getViewerPoint(viewer, evt));
       const { x, y } = viewer.viewport.viewportToImageCoordinates(pt.x, pt.y);
       const buffer = getHitTolerance();
 

--- a/packages/annotorious-openseadragon/src/annotation/svg/drawing/SVGDrawingLayer.svelte
+++ b/packages/annotorious-openseadragon/src/annotation/svg/drawing/SVGDrawingLayer.svelte
@@ -97,10 +97,27 @@
     }
   }
 
-  // Coordinate transform, element offset to OSD image coordinates
+  // Convert a screen pointer position into the viewer's untransformed local
+  // coordinate system. This keeps OSD viewport mapping correct when the viewer
+  // sits inside a CSS-transformed ancestor.
+  const getViewerPoint = (evt: PointerEvent): OpenSeadragon.Point => {
+    const { left, top, width, height } = viewer.element.getBoundingClientRect();
+
+    return new OpenSeadragon.Point(
+      (evt.clientX - left) * (viewer.element.clientWidth / width),
+      (evt.clientY - top) * (viewer.element.clientHeight / height)
+    );
+  }
+
+  // Coordinate transform, viewer-local pixels to OSD image coordinates
   const toolTransform = (offsetX: number, offsetY: number): [number, number] => {
     const {x, y} = viewer.viewport.viewerElementToImageCoordinates(new OpenSeadragon.Point(offsetX, offsetY));
     return [x, y];
+  }
+
+  const eventToImage = (evt: PointerEvent): [number, number] => {
+    const { x, y } = getViewerPoint(evt);
+    return toolTransform(x, y);
   }
 
   const getCurrentScale = () => {
@@ -125,8 +142,7 @@
     const timeDifference = performance.now() - (grabbedAt || 0);
     if (timeDifference < 300) {
       // Click - check if another shape needs selecting
-      const { offsetX, offsetY } = evt.detail;
-      const [x, y] = toolTransform(offsetX, offsetY);
+      const [x, y] = eventToImage(evt.detail);
       const buffer = getHitTolerance();
 
       const hit = store.getAt(x, y, undefined, buffer);
@@ -142,8 +158,7 @@
   }
 
   const onPointerMove = (evt: PointerEvent) => {
-    const offsetXY = new OpenSeadragon.Point(evt.offsetX, evt.offsetY);
-    const pt = viewer.viewport.pointFromPixel(offsetXY);
+    const pt = viewer.viewport.pointFromPixel(getViewerPoint(evt));
     const { x, y } = viewer.viewport.viewportToImageCoordinates(pt.x, pt.y);
 
     const buffer = getHitTolerance();
@@ -207,8 +222,7 @@
     const onPointerMove = (evt: PointerEvent) => {
       if (($selection as Selection).selected.length === 0) return;
 
-      const { offsetX, offsetY } = evt;
-      const pt = viewer.viewport.pointFromPixel(new OpenSeadragon.Point(offsetX, offsetY));
+      const pt = viewer.viewport.pointFromPixel(getViewerPoint(evt));
       const { x, y } = viewer.viewport.viewportToImageCoordinates(pt.x, pt.y);
       const buffer = getHitTolerance();
 

--- a/packages/annotorious-openseadragon/src/utils/getViewerPoint.ts
+++ b/packages/annotorious-openseadragon/src/utils/getViewerPoint.ts
@@ -1,0 +1,13 @@
+import OpenSeadragon from 'openseadragon';
+
+// Convert screen coordinates to the viewer's untransformed local coordinate
+// system. OSD's viewport APIs expect these layout pixels, while PointerEvent
+// offsets are inconsistent when an HTML ancestor is CSS-transformed.
+export const getViewerPoint = (viewer: OpenSeadragon.Viewer, evt: PointerEvent): OpenSeadragon.Point => {
+  const { left, top, width, height } = viewer.element.getBoundingClientRect();
+
+  return new OpenSeadragon.Point(
+    (evt.clientX - left) * (viewer.element.clientWidth / width),
+    (evt.clientY - top) * (viewer.element.clientHeight / height)
+  );
+}

--- a/packages/annotorious-openseadragon/src/utils/getViewerPoint.ts
+++ b/packages/annotorious-openseadragon/src/utils/getViewerPoint.ts
@@ -1,13 +1,10 @@
 import OpenSeadragon from 'openseadragon';
+import { getElementPoint } from '@annotorious/annotorious';
 
 // Convert screen coordinates to the viewer's untransformed local coordinate
 // system. OSD's viewport APIs expect these layout pixels, while PointerEvent
 // offsets are inconsistent when an HTML ancestor is CSS-transformed.
 export const getViewerPoint = (viewer: OpenSeadragon.Viewer, evt: PointerEvent): OpenSeadragon.Point => {
-  const { left, top, width, height } = viewer.element.getBoundingClientRect();
-
-  return new OpenSeadragon.Point(
-    (evt.clientX - left) * (viewer.element.clientWidth / width),
-    (evt.clientY - top) * (viewer.element.clientHeight / height)
-  );
+  const [x, y] = getElementPoint(viewer.element, evt);
+  return new OpenSeadragon.Point(x, y);
 }

--- a/packages/annotorious-openseadragon/src/utils/index.ts
+++ b/packages/annotorious-openseadragon/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './getViewerPoint';
 export * from './updateSelection';

--- a/packages/annotorious-react/test/openseadragon-coordinate-mapping/App.tsx
+++ b/packages/annotorious-react/test/openseadragon-coordinate-mapping/App.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react';
+import OpenSeadragon from 'openseadragon';
+import {
+  AnnotoriousOpenSeadragonAnnotator,
+  ImageAnnotation,
+  OpenSeadragonAnnotator,
+  OpenSeadragonViewer,
+  useAnnotations,
+  useAnnotator,
+  useSelection
+} from '../../src';
+
+const INITIAL_ANNOTATION: ImageAnnotation = {
+  id: 'test-rectangle',
+  bodies: [],
+  target: {
+    annotation: 'test-rectangle',
+    selector: {
+      type: 'RECTANGLE',
+      geometry: {
+        bounds: { minX: 180, minY: 85, maxX: 370, maxY: 230 },
+        x: 180,
+        y: 85,
+        w: 190,
+        h: 145,
+        rot: 0
+      }
+    }
+  }
+};
+
+const VIEWER_OPTIONS: OpenSeadragon.Options = {
+  prefixUrl: 'https://cdn.jsdelivr.net/npm/openseadragon@5.0/build/openseadragon/images/',
+  showNavigator: true,
+  tileSources: {
+    type: 'image',
+    url: '/test/image/640px-Hallstatt.jpg'
+  },
+  gestureSettingsMouse: { clickToZoom: false },
+  // Let the playground exercise hit testing and editing at magnifications well
+  // beyond the image's native resolution.
+  maxZoomPixelRatio: 8,
+  zoomPerClick: 2,
+  zoomPerScroll: 1.5
+};
+
+const Diagnostics = () => {
+  const annotations = useAnnotations();
+  const selection = useSelection();
+
+  return (
+    <output className="diagnostics" aria-live="polite">
+      <div><strong>Selected:</strong> {selection.selected.map(({ annotation }) => annotation.id).join(', ') || 'none'}</div>
+      <div><strong>Annotations:</strong> {annotations.length}</div>
+      <pre>{JSON.stringify(annotations.map(({ id, target }) => ({ id, geometry: target.selector.geometry })), null, 2)}</pre>
+    </output>
+  );
+};
+
+export const App = () => {
+  const anno = useAnnotator<AnnotoriousOpenSeadragonAnnotator>();
+  const [drawing, setDrawing] = useState(false);
+  const [transformed, setTransformed] = useState(true);
+
+  useEffect(() => {
+    if (anno)
+      anno.setAnnotations([INITIAL_ANNOTATION]);
+  }, [anno]);
+
+  useEffect(() => {
+    anno?.setDrawingEnabled(drawing);
+  }, [anno, drawing]);
+
+  return (
+    <main>
+      <header>
+        <div>
+          <h1>OpenSeadragon coordinate-mapping playground</h1>
+          <p>
+            The viewer is inside a CSS-transformed ancestor by default. Select the red
+            rectangle, drag it or a handle, then enable drawing and add another rectangle.
+          </p>
+        </div>
+        <div className="controls">
+          <button onClick={() => setTransformed(value => !value)}>
+            {transformed ? 'Disable CSS transform' : 'Enable CSS transform'}
+          </button>
+          <button onClick={() => setDrawing(value => !value)}>
+            {drawing ? 'Stop drawing' : 'Draw rectangle'}
+          </button>
+        </div>
+      </header>
+
+      <section className={transformed ? 'transformed' : undefined}>
+        <OpenSeadragonAnnotator drawingMode="drag">
+          <OpenSeadragonViewer className="viewer" options={VIEWER_OPTIONS} />
+        </OpenSeadragonAnnotator>
+      </section>
+
+      <Diagnostics />
+    </main>
+  );
+};

--- a/packages/annotorious-react/test/openseadragon-coordinate-mapping/README.md
+++ b/packages/annotorious-react/test/openseadragon-coordinate-mapping/README.md
@@ -1,0 +1,13 @@
+# OpenSeadragon coordinate-mapping playground
+
+Run `npm run playground:osd` from the repository root. The page starts with a
+translated and scaled ancestor around the viewer, which is the condition that
+previously sent pointer coordinates to the wrong image position.
+
+Verify these interactions with the transform both enabled and disabled:
+
+1. Select the seeded red rectangle, then select another shape to verify that the selection switches.
+2. Drag the shape and each resize handle; the live geometry should follow the pointer.
+3. Enable drawing and drag out a second rectangle; it should appear where the drag began.
+4. Pan and zoom the image up to 8× its native pixel resolution, then repeat
+   selection and editing.

--- a/packages/annotorious-react/test/openseadragon-coordinate-mapping/README.md
+++ b/packages/annotorious-react/test/openseadragon-coordinate-mapping/README.md
@@ -1,8 +1,8 @@
 # OpenSeadragon coordinate-mapping playground
 
 Run `npm run playground:osd` from the repository root. The page starts with a
-translated and scaled ancestor around the viewer, which is the condition that
-previously sent pointer coordinates to the wrong image position.
+translated and scaled ancestor around the viewer — the setup that previously
+sent pointer coordinates to the wrong image position.
 
 Verify these interactions with the transform both enabled and disabled:
 

--- a/packages/annotorious-react/test/openseadragon-coordinate-mapping/index.html
+++ b/packages/annotorious-react/test/openseadragon-coordinate-mapping/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Annotorious OSD coordinate mapping playground</title>
+    <style>
+      :root { color: #172033; font-family: system-ui, sans-serif; background: #f3f5f8; }
+      body { margin: 0; }
+      main { margin: 0 auto; max-width: 960px; padding: 32px 24px 64px; }
+      header { align-items: start; display: flex; gap: 24px; justify-content: space-between; margin-bottom: 28px; }
+      h1 { font-size: 1.5rem; margin: 0 0 8px; }
+      p { line-height: 1.5; margin: 0; max-width: 630px; }
+      .controls { display: flex; flex: none; flex-direction: column; gap: 8px; }
+      button { background: #fff; border: 1px solid #aab4c5; border-radius: 6px; color: inherit; cursor: pointer; padding: 8px 12px; }
+      button:hover { background: #edf2fa; }
+      section { background: #152235; box-shadow: 0 10px 30px rgba(23, 32, 51, .2); height: 430px; transform-origin: top center; transition: transform 160ms ease; }
+      section.transformed { transform: translate(36px, 20px) scale(0.88); }
+      .viewer { height: 100%; width: 100%; }
+      .diagnostics { background: #fff; border: 1px solid #d3dae5; display: block; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .8rem; line-height: 1.45; margin-top: 52px; overflow: auto; padding: 16px; }
+      .diagnostics pre { margin: 12px 0 0; }
+      @media (max-width: 720px) { header { flex-direction: column; } .controls { flex-direction: row; } section.transformed { transform: translate(16px, 12px) scale(.92); } }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.tsx"></script>
+  </body>
+</html>

--- a/packages/annotorious-react/test/openseadragon-coordinate-mapping/index.tsx
+++ b/packages/annotorious-react/test/openseadragon-coordinate-mapping/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { Annotorious } from '../../src';
+import { App } from './App';
+
+createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <Annotorious>
+      <App />
+    </Annotorious>
+  </React.StrictMode>
+);

--- a/packages/annotorious/src/annotation/SVGAnnotationLayerPointerEvent.ts
+++ b/packages/annotorious/src/annotation/SVGAnnotationLayerPointerEvent.ts
@@ -42,15 +42,16 @@ export const addEventListeners = <T extends Annotation>(svg: SVGSVGElement, stor
 }
 
 export const getSVGPoint = (evt: PointerEvent, svg: SVGSVGElement) => {
-  const pt = svg.createSVGPoint();
+  // Maps the pointer position to image space proportionally via the bounding box
+  // and viewBox, which always equals the image's natural size. Deliberately avoids
+  // getScreenCTM: browsers disagree on whether CSS transforms on HTML ancestors are
+  // reflected in the CTM (e.g. WebKit bug 209220), which sends hit-tests to the
+  // wrong coordinates when the annotator is embedded in a CSS-transformed container.
   const bbox = svg.getBoundingClientRect();
+  const { width, height } = svg.viewBox.baseVal;
 
-  const x = evt.clientX - bbox.x;
-  const y = evt.clientY - bbox.y;
-
-  const { left, top } = svg.getBoundingClientRect();
-  pt.x = x + left;
-  pt.y = y + top;
-
-  return pt.matrixTransform(svg.getScreenCTM()!.inverse());
+  return {
+    x: (evt.clientX - bbox.x) / bbox.width * width,
+    y: (evt.clientY - bbox.y) / bbox.height * height
+  };
 }

--- a/packages/annotorious/src/annotation/SVGAnnotationLayerPointerEvent.ts
+++ b/packages/annotorious/src/annotation/SVGAnnotationLayerPointerEvent.ts
@@ -42,11 +42,8 @@ export const addEventListeners = <T extends Annotation>(svg: SVGSVGElement, stor
 }
 
 export const getSVGPoint = (evt: PointerEvent, svg: SVGSVGElement) => {
-  // Maps the pointer position to image space proportionally via the bounding box
-  // and viewBox, which always equals the image's natural size. Deliberately avoids
-  // getScreenCTM: browsers disagree on whether CSS transforms on HTML ancestors are
-  // reflected in the CTM (e.g. WebKit bug 209220), which sends hit-tests to the
-  // wrong coordinates when the annotator is embedded in a CSS-transformed container.
+  // Same viewBox-based mapping as createSVGTransform in Transform.ts — see
+  // there for why getScreenCTM is avoided.
   const bbox = svg.getBoundingClientRect();
   const { width, height } = svg.viewBox.baseVal;
 

--- a/packages/annotorious/src/annotation/Transform.ts
+++ b/packages/annotorious/src/annotation/Transform.ts
@@ -12,15 +12,19 @@ export const IdentityTransform: Transform = {
 
 export const createSVGTransform = (svg: SVGSVGElement): Transform => ({
 
+  // Maps element-local (offsetX-style) coordinates to image space proportionally
+  // via the viewBox, which always equals the image's natural size. Deliberately
+  // avoids getScreenCTM: browsers disagree on whether CSS transforms on HTML
+  // ancestors are reflected in the CTM (e.g. WebKit bug 209220), which breaks
+  // drawing and editing when the annotator is embedded in a CSS-transformed
+  // container such as a pan-zoom wrapper.
   elementToImage: (offsetX: number, offsetY: number) => {
-    const bbox = svg.getBoundingClientRect();
+    const { width, height } = svg.viewBox.baseVal;
 
-    const pt = svg.createSVGPoint();
-    pt.x = offsetX + bbox.x;
-    pt.y = offsetY + bbox.y;
-  
-    const { x, y } = pt.matrixTransform(svg.getScreenCTM()!.inverse());
-    return [x, y];
+    return [
+      offsetX / svg.clientWidth * width,
+      offsetY / svg.clientHeight * height
+    ];
   }
 
 });

--- a/packages/annotorious/src/annotation/editors/Editor.svelte
+++ b/packages/annotorious/src/annotation/editors/Editor.svelte
@@ -25,9 +25,12 @@
     // new PolygonEditor. Old versions of Annotorious, however, 
     // won't yet forward the svgEl prop!
     if (svgEl) {
-      const { left, top } = svgEl.getBoundingClientRect();
-      const offsetX = evt.clientX - left;
-      const offsetY = evt.clientY - top;
+      // Convert screen px to element-local px so the input space matches
+      // elementToImage's offsetX-style contract when an ancestor CSS transform
+      // makes the bounding box differ from the layout box.
+      const { left, top, width, height } = svgEl.getBoundingClientRect();
+      const offsetX = (evt.clientX - left) * (svgEl.clientWidth / width);
+      const offsetY = (evt.clientY - top) * (svgEl.clientHeight / height);
 
       origin = transform.elementToImage(offsetX, offsetY);
     } else {

--- a/packages/annotorious/src/annotation/editors/Editor.svelte
+++ b/packages/annotorious/src/annotation/editors/Editor.svelte
@@ -2,6 +2,7 @@
   import { createEventDispatcher } from 'svelte';
   import type { Shape } from '../../model';
   import type { Transform } from '../Transform';
+  import { getElementPoint } from '../utils';
 
   const dispatch = createEventDispatcher<{ grab: PointerEvent, release: PointerEvent, change: Shape }>();
 
@@ -25,13 +26,7 @@
     // new PolygonEditor. Old versions of Annotorious, however, 
     // won't yet forward the svgEl prop!
     if (svgEl) {
-      // Convert screen px to element-local px so the input space matches
-      // elementToImage's offsetX-style contract when an ancestor CSS transform
-      // makes the bounding box differ from the layout box.
-      const { left, top, width, height } = svgEl.getBoundingClientRect();
-      const offsetX = (evt.clientX - left) * (svgEl.clientWidth / width);
-      const offsetY = (evt.clientY - top) * (svgEl.clientHeight / height);
-
+      const [offsetX, offsetY] = getElementPoint(svgEl, evt);
       origin = transform.elementToImage(offsetX, offsetY);
     } else {
       const { offsetX, offsetY } = evt;

--- a/packages/annotorious/src/annotation/utils/index.ts
+++ b/packages/annotorious/src/annotation/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './pointer';
 export * from './responsive';
 export * from './styling';
 export * from './svg';

--- a/packages/annotorious/src/annotation/utils/pointer.ts
+++ b/packages/annotorious/src/annotation/utils/pointer.ts
@@ -1,0 +1,13 @@
+// Convert a pointer event's screen position into the element's local,
+// layout-space coordinates (the native offsetX/offsetY contract). Needed for
+// synthetic events, which don't carry offsetX/offsetY, while staying correct
+// when an ancestor CSS transform makes the bounding box differ from the
+// layout box.
+export const getElementPoint = (el: Element, evt: PointerEvent): [number, number] => {
+  const { left, top, width, height } = el.getBoundingClientRect();
+
+  return [
+    (evt.clientX - left) * (el.clientWidth / width),
+    (evt.clientY - top) * (el.clientHeight / height)
+  ];
+}

--- a/packages/annotorious/test/annotation/Transform.test.ts
+++ b/packages/annotorious/test/annotation/Transform.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { createSVGTransform } from '../../src/annotation/Transform';
+
+describe('createSVGTransform', () => {
+  it('scales offset coordinates by the viewBox/client-size ratio', () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg') as SVGSVGElement;
+    svg.setAttribute('viewBox', '0 0 800 600');
+    Object.defineProperty(svg, 'clientWidth', { value: 400, configurable: true });
+    Object.defineProperty(svg, 'clientHeight', { value: 300, configurable: true });
+
+    // Scale factor is 2x on both axes here, regardless of any ancestor CSS
+    // transform - jsdom doesn't implement getScreenCTM, so this also proves
+    // the mapping no longer depends on it.
+    expect(createSVGTransform(svg).elementToImage(100, 50)).toEqual([200, 100]);
+  });
+});

--- a/packages/annotorious/test/annotation/Transform.test.ts
+++ b/packages/annotorious/test/annotation/Transform.test.ts
@@ -2,15 +2,16 @@ import { describe, expect, it } from 'vitest';
 import { createSVGTransform } from '../../src/annotation/Transform';
 
 describe('createSVGTransform', () => {
-  it('scales offset coordinates by the viewBox/client-size ratio', () => {
+  it('scales offset coordinates by the viewBox/client-size ratio, not by bounding-box or CTM geometry', () => {
     const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg') as SVGSVGElement;
     svg.setAttribute('viewBox', '0 0 800 600');
+
+    // jsdom has no layout engine, so a real CSS transform wouldn't change
+    // clientWidth/clientHeight - these stand in for what a 2x-scaled ancestor
+    // would produce, which getBoundingClientRect/getScreenCTM get wrong.
     Object.defineProperty(svg, 'clientWidth', { value: 400, configurable: true });
     Object.defineProperty(svg, 'clientHeight', { value: 300, configurable: true });
 
-    // Scale factor is 2x on both axes here, regardless of any ancestor CSS
-    // transform - jsdom doesn't implement getScreenCTM, so this also proves
-    // the mapping no longer depends on it.
     expect(createSVGTransform(svg).elementToImage(100, 50)).toEqual([200, 100]);
   });
 });


### PR DESCRIPTION
## What changed
- Map pointer coordinates via `viewBox`/bounding-box ratios instead of `getScreenCTM()`
(`Transform.ts`, `SVGAnnotationLayerPointerEvent.ts`, `Editor.svelte`), and via the
viewer's bounding rect instead of OSD's raw offsets (shared `getViewerPoint` util, used
by the Pixi and SVG drawing layers).
- Add an OpenSeadragon coordinate-mapping playground (`npm run playground:osd`) and a unit
test for `createSVGTransform` - do we need the playgroun?

## OSD playground app
Manual: `npm run playground:osd`, toggle the CSS transform, then select, drag, resize,
draw, and zoom to 2-8x.

Resolves: https://github.com/annotorious/annotorious/issues/613